### PR TITLE
If OctoToggle is down, retain feature toggle cache and log warning

### DIFF
--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -47,7 +47,7 @@ namespace Octopus.OpenFeature.Provider
             }
             
 #pragma warning disable OCT1015
-            if (DateTime.Now < lastRefreshed + configuration.CacheRefreshInterval)
+            if (DateTime.Now < lastRefreshed + configuration.CacheDuration)
 #pragma warning restore OCT1015
             {
                 return false;

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureConfiguration.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureConfiguration.cs
@@ -25,7 +25,7 @@ namespace Octopus.OpenFeature.Provider
         /// The amount of time between checks to see if new feature toggles are available
         /// The cache will be refreshed if new feature toggles are available
         /// </summary>
-        public TimeSpan CacheRefreshInterval { get; set; } = TimeSpan.FromMinutes(1);
+        public TimeSpan CacheDuration { get; set; } = TimeSpan.FromMinutes(1);
         
         public CancellationToken CancellationToken { get; set; } = CancellationToken.None;
 


### PR DESCRIPTION
If OctoToggle is down and the client cannot refresh it's cache of enabled feature toggles, we will retain the existing cache  and log warnings.

This should give us stability if OctoToggle is uncontactable for "a while", but also ensure there is a signal to the consumer at some point if it is uncontactable.

Slack thread: https://octopusdeploy.slack.com/archives/C06UUFZSCC9/p1719373119574039