### PR TITLE
Tolerates null context values in evaluations

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -156,4 +156,20 @@ public class OctopusFeatureContextTests
         // None specified
         context.Evaluate("testfeature", true, context: null).Value.Should().BeFalse();
     }
+    
+    [Fact]
+    public void
+        GivenASetOfFeatureToggles_WhenAFeatureIsToggledOnForASpecificSegment_ToleratesNullValuesInContext()
+    {
+        var featureToggles = new FeatureToggles([
+            new FeatureToggleEvaluation("testfeature", "testfeature", true, [new("license", "trial")])
+        ], []);
+
+        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
+
+        using var scope = new AssertionScope();
+        context.Evaluate("testfeature", false, context: BuildContext([("license", null)!])).Value.Should().BeFalse();
+        context.Evaluate("testfeature", false, context: BuildContext([("other", "segment")])).Value.Should().BeFalse();
+        context.Evaluate("testfeature", false, context: null).Value.Should().BeFalse();
+    }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -53,7 +53,7 @@ public partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactor
         return segments.Any(segment =>
             contextValues.Any(x =>
                 x.Key.Equals(segment.Key, StringComparison.OrdinalIgnoreCase)
-                && x.Value.AsString.Equals(segment.Value, StringComparison.OrdinalIgnoreCase)));
+                && x.Value.AsString is { } value && value.Equals(segment.Value, StringComparison.OrdinalIgnoreCase)));
     }
 
     bool Evaluate(FeatureToggleEvaluation evaluation, EvaluationContext? context = null)


### PR DESCRIPTION
We found that if a null value was set in `EvaluationContext` it would cause the client to throw a null reference exception.

Context: https://octopusdeploy.slack.com/archives/C06UUFZSCC9/p1720149707108809

This PR ensures the client appropriately checks context values before trying to compare them to segments.