### PR TITLE
Adds segment evaluators

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/SegmentEvaluatorTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/SegmentEvaluatorTests.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+
+namespace Octopus.OpenFeature.Provider.Tests;
+
+public class SegmentEvaluatorTests
+{
+    [Theory]
+    [InlineData("1.0.0", "1.0.1", true, "true when context version is greater than segment version")]
+    [InlineData("1.0.0-mybranch", "1.0.1-mybranch", true, "tolerates pre-release versions")]
+    [InlineData("1.0.1", "1.0.0", false, "false when context version is less than segment version")]
+    [InlineData("1.0.1", "1.0.1", true, "true when context version is equal to segment version")]
+    public void GivenASemanticVersionSegmentEvaluator_EvaluatesAsExpected(string segmentVersion, string contextVersion, bool expectedValue, string reason)
+    {
+        var evaluator = new SemanticVersionSegmentEvaluator();
+
+        var result = evaluator.Evaluate(segmentVersion, contextVersion);
+
+        result.Should().Be(expectedValue);
+    }
+}

--- a/src/Octopus.OpenFeature.Provider/ISegmentEvaluator.cs
+++ b/src/Octopus.OpenFeature.Provider/ISegmentEvaluator.cs
@@ -1,0 +1,38 @@
+using Semver;
+
+namespace Octopus.OpenFeature.Provider;
+
+interface ISegmentEvaluator
+{
+    bool CanEvaluate(string segmentValue, string contextValue);
+    bool Evaluate(string segmentValue, string contextValue);
+}
+
+class SemanticVersionSegmentEvaluator : ISegmentEvaluator
+{
+    public bool CanEvaluate(string segmentValue, string contextValue)
+    {
+        return SemVersion.TryParse(segmentValue, out _) && SemVersion.TryParse(contextValue, out _);
+    }
+
+    public bool Evaluate(string segmentValue, string contextValue)
+    {
+        var segmentVersion = SemVersion.Parse(segmentValue);
+        var contextVersion = SemVersion.Parse(contextValue);
+
+        return SemVersion.CompareSortOrder(segmentVersion, contextVersion) <= 0;
+    }
+}
+
+class DefaultSegmentEvaluator : ISegmentEvaluator
+{
+    public bool CanEvaluate(string segmentValue, string contextValue)
+    {
+        return true;
+    }
+
+    public bool Evaluate(string segmentValue, string contextValue)
+    {
+        return contextValue.Equals(segmentValue, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Octopus.OpenFeature.Provider/Octopus.OpenFeature.Provider.csproj
+++ b/src/Octopus.OpenFeature.Provider/Octopus.OpenFeature.Provider.csproj
@@ -20,6 +20,7 @@
 
     <ItemGroup>
         <PackageReference Include="OpenFeature" Version="2.0.0" />
+        <PackageReference Include="Semver" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We have had several requests to be able to toggle a feature toggle on based on a minimum server version

Context: https://octopusdeploy.slack.com/archives/C06UUFZSCC9/p1742516433295149

This PR introduces the concept of segment evaluators into our server openfeature client.

There is a `DefaultSegmentEvaluator`, which simply does a string comparison between the segment and context values.

And there is a new `SemanticVersionSegmentEvaluator`, which, if both the segment and the context value can be parsed as semantic versions, will do a "greater or equal to" comparison between these values, and if the context value is greater than or equal to the segment value, it will evaluate as true.

There is a downside to this approach: when there are multiple segments, the set is not evaluated as `and` - it is evaluated as `or` - if any segments match, it is good to go. This would mean if you had ANOTHER segment that matched for a given context - say a username, we would still get a `true` evaluation for the toggle, even if the version segment did not evaluate positively.

Putting this PR up more as a discussion point than an intention to merge to see if we might get towards a "simple" solution that doesn't require sweeping changes to the feature toggle domain / OctoToggle.

Ideas
====

We could be even more clever with evaluating the set, and identify any toggle that has a specific evaluator as "required". This would mean the semver evaluator would HAVE to return positively, and anything that passes the default evaluator would have just to pass one of, if any existed.

Downside to this is it gets pretty hard to reason about. It would work, but you'd need to know the innards of the evaluator function to figure out what was going on, rather than it being a simpler function of how you configured the toggle.