### PR TITLE
🧹 Added dependabot and implemented hash pinning for third party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./build.sh --verbosity verbose
 
       - name: Unit test report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()
         with:
           name: Unit test results


### PR DESCRIPTION
Added dependabot to check github actions and pinned third party actions, have left the default github and the internal packages.

[sc-105971]

Dependabot will now run weekly for this repo and check the github actions for updates

Also updated dorny/test-reporter to v2, and pinned release