### PR TITLE
Lower target framework to netstandard2.0

### DIFF
--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel;
-using System.Linq;
 using Nuke.Common.Tooling;
 
 [TypeConverter(typeof(TypeConverter<Configuration>))]

--- a/src/Octopus.OpenFeature.Provider/Octopus.OpenFeature.Provider.csproj
+++ b/src/Octopus.OpenFeature.Provider/Octopus.OpenFeature.Provider.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
         <AssemblyName>Octopus.OpenFeature.Provider</AssemblyName>
         <PackageId>Octopus.OpenFeature</PackageId>
         <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
@@ -20,6 +21,7 @@
 
     <ItemGroup>
         <PackageReference Include="OpenFeature" Version="2.0.0" />
+        <PackageReference Include="System.Text.Json" Version="9.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -58,6 +58,8 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
             if (result is not null && result.IsSuccessStatusCode)
             {
                 var rawResult = await result.Content.ReadAsStringAsync();
+                
+                logger.LogInformation("Retrieved feature toggles {Result}", rawResult);
             
                 hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult);
             }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -59,9 +59,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
             {
                 var rawResult = await result.Content.ReadAsStringAsync();
                 
-                logger.LogInformation("Retrieved feature toggles {Result}", rawResult);
-            
-                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult);
+                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult, JsonSerializerOptions.Web);
             }
         }
         else
@@ -72,7 +70,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
             {
                 var rawResult = await result.Content.ReadAsStringAsync();
             
-                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult);
+                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult, JsonSerializerOptions.Web);
             }
         }
             
@@ -136,7 +134,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         // This code will need to update accordingly
         var result = await response.Content.ReadAsStringAsync();
         
-        var evaluations = JsonSerializer.Deserialize<FeatureToggleEvaluation[]>(result);
+        var evaluations = JsonSerializer.Deserialize<FeatureToggleEvaluation[]>(result, JsonSerializerOptions.Web);
         
         if (evaluations is null)
         {

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -1,11 +1,26 @@
 using System.Net;
-using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
+using System.Text.Json;
 
 namespace Octopus.OpenFeature.Provider;
 
-public record FeatureToggles(FeatureToggleEvaluation[] Evaluations, byte[] ContentHash);
-public record FeatureToggleEvaluation(string Name, string Slug, bool IsEnabled, KeyValuePair<string, string>[] Segments);
+public class FeatureToggles(FeatureToggleEvaluation[] evaluations, byte[] contentHash)
+{
+    public FeatureToggleEvaluation[] Evaluations { get; } = evaluations;
+    
+    public byte[] ContentHash { get; } = contentHash;
+}
+
+public class FeatureToggleEvaluation(string name, string slug, bool isEnabled, KeyValuePair<string, string>[] segments)
+{
+    public string Name { get; } = name;
+    
+    public string Slug { get; } = slug;
+    
+    public bool IsEnabled { get; } = isEnabled;
+    
+    public KeyValuePair<string, string>[] Segments { get; } = segments;
+}
 
 interface IOctopusFeatureClient
 {
@@ -33,16 +48,30 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         // WARNING: v2 and v3 check endpoints have identical response contracts.
         // If for any reason the v3 endpoint response contract starts to diverge from the v2 contract,
         // This code will need to update accordingly
-        FeatureCheck? hash;
+        FeatureCheck? hash = null;
         if (configuration.IsV3ClientIdentifierSupplied())
         {
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
+
+            var result = await ExecuteWithRetry(async ct => await client.GetAsync("api/featuretoggles/check/v3/", ct), cancellationToken);
+
+            if (result is not null && result.IsSuccessStatusCode)
+            {
+                var rawResult = await result.Content.ReadAsStringAsync();
             
-            hash = await ExecuteWithRetry(async ct => await client.GetFromJsonAsync<FeatureCheck>("api/featuretoggles/check/v3/", ct), cancellationToken);
+                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult);
+            }
         }
         else
         {
-            hash = await ExecuteWithRetry(async ct => await client.GetFromJsonAsync<FeatureCheck>($"api/featuretoggles/{configuration.ClientIdentifier}/check", ct), cancellationToken);
+            var result = await ExecuteWithRetry(async ct => await client.GetAsync($"api/featuretoggles/{configuration.ClientIdentifier}/check", ct), cancellationToken);
+            
+            if (result is not null && result.IsSuccessStatusCode)
+            {
+                var rawResult = await result.Content.ReadAsStringAsync();
+            
+                hash = JsonSerializer.Deserialize<FeatureCheck>(rawResult);
+            }
         }
             
         if (hash is null)
@@ -56,7 +85,10 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         return haveFeaturesChanged;
     }
 
-    record FeatureCheck(byte[] ContentHash);
+    class FeatureCheck(byte[] contentHash)
+    {
+        public byte[] ContentHash { get; } = contentHash;
+    }
 
     /// <summary>
     /// Retrieves the evaluated feature set from OctoToggle for a given installation and project.
@@ -100,7 +132,10 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         // WARNING: v2 and v3 endpoints have identical response contracts.
         // If for any reason the v3 endpoint response contract starts to diverge from the v2 contract,
         // This code will need to update accordingly
-        var evaluations = await response.Content.ReadFromJsonAsync<FeatureToggleEvaluation[]>(cancellationToken);
+        var result = await response.Content.ReadAsStringAsync();
+        
+        var evaluations = JsonSerializer.Deserialize<FeatureToggleEvaluation[]>(result);
+        
         if (evaluations is null)
         {
             logger.LogWarning("Feature toggle response content from {OctoToggleUrl} was empty.", configuration.ServerUri);

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureConfiguration.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureConfiguration.cs
@@ -34,7 +34,7 @@ public class OctopusFeatureConfiguration
     public bool IsV3ClientIdentifierSupplied()
     {
         // A very basic test to see if we have a JWT-formatted client identifier
-        var tokenSegments = ClientIdentifier.Split(".");
+        var tokenSegments = ClientIdentifier.Split('.');
         return tokenSegments.Length == 3;
     }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -8,7 +8,7 @@ namespace Octopus.OpenFeature.Provider;
 partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory loggerFactory)
 {
     public byte[] ContentHash => toggles.ContentHash;
-    readonly Regex expression = SlugExpression();
+    readonly Regex expression = new("^([a-z0-9]+(-[a-z0-9]+)*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     readonly ILogger logger = loggerFactory.CreateLogger<OctopusFeatureContext>();
 
     public static OctopusFeatureContext Empty(ILoggerFactory loggerFactory)
@@ -63,7 +63,4 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
         return evaluation.IsEnabled &&
                (evaluation.Segments.Length == 0 || MatchesSegment(context, evaluation.Segments));
     }
-
-    [GeneratedRegex("^([a-z0-9]+(-[a-z0-9]+)*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
-    private static partial Regex SlugExpression();
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
@@ -89,7 +89,7 @@ class OctopusFeatureContextProvider(
             
     public async ValueTask Shutdown()
     {
-        await cancellationTokenSource.CancelAsync();
+        cancellationTokenSource.Cancel();
 
         if (evaluationContextRefreshTask is not null)
         {


### PR DESCRIPTION
To support a broader range of dotnet versions being able to use the Octopus openfeature dotnet provider, this PR lowers the target framework to `netstandard2.0`.

https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0 contains what versions will be able to consume the provider after this change merges.