### PR TITLE
test: Add unicode test cases

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -69,7 +69,7 @@ public class OctopusFeatureContextTests
     public void EvaluatesToDefaultValue_IfFeatureIsNotContainedWithinSet()
     {
         var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("testfeature", true, "evaluation-key", [], 100)
+            new FeatureToggleEvaluation("testfeature", false, "evaluation-key", [], 100)
         ], []);
 
         var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
@@ -409,6 +409,16 @@ public class OctopusFeatureContextTests
     [InlineData("bucket", "j", 1)]
     [InlineData("test", "y", 100)]
     [InlineData("flag", "c", 100)]
+    [InlineData("test-feature", "用户", 30)]
+    [InlineData("test-feature", "مستخدم", 19)]
+    [InlineData("test-feature", "ユーザー", 73)]
+    [InlineData("test-feature", "🎉", 54)]
+    [InlineData("test-feature", "café", 31)]
+    [InlineData("test-feature", "naïve", 28)]
+    [InlineData("rollout", "用户-001", 20)]
+    [InlineData("experiment-a", "пользователь", 81)]
+    [InlineData("test-feature", "사용자", 62)]
+    [InlineData("dark-launch", "テナント-001", 8)]
     public void GetNormalizedNumber_MatchesExpectedValue(string evaluationKey, string targetingKey, int expected)
     {
         OctopusFeatureContext.GetNormalizedNumber(evaluationKey, targetingKey).Should().Be(expected);


### PR DESCRIPTION
# Background

While [adding fractional evaluation to the TypeScript provider library](https://linear.app/octopus/issue/DEVEX-81/add-fractional-evaluation-support-to-typescript-client-library), a gap in testing was identified: correct hashing of strings containing non-Latin alphanumeric characters.

# Changes

* Added test cases for a variety of character types.
* Also updated a test that was asserting a default value where the evaluated value was the same as the default.

These align with these PRs for the other libraries:
* https://github.com/OctopusDeploy/openfeature-provider-java/pull/9
* https://github.com/OctopusDeploy/openfeature-provider-ts-web/pull/49