### PR TITLE
docs: Fix errors in the getting-started example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ await OpenFeature.Api.Instance.SetProviderAsync(provider);
 
 var client = OpenFeature.Api.Instance.GetClient();
 
-if (await client.GetBooleanValue("to-the-moon-feature", false))
+if (await client.GetBooleanValueAsync("to-the-moon-feature", false))
 {
   Console.WriteLine("🚀🚀🚀");
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet add package Octopus.OpenFeature
 ```c#
 var clientIdentifier = Environment.GetEnvironmentVariable("Octopus__Features__ClientIdentifier");
 
-var provider = new OctopusFeatureProvider(new OctopusFeatureConfiguration(clientIdentifier, new ProductMetadata("MyProductName"));
+var provider = new OctopusFeatureProvider(new OctopusFeatureConfiguration(clientIdentifier, new ProductMetadata("MyProductName")));
 
 await OpenFeature.Api.Instance.SetProviderAsync(provider);
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dotnet add package Octopus.OpenFeature
 ```c#
 var clientIdentifier = Environment.GetEnvironmentVariable("Octopus__Features__ClientIdentifier");
 
-var provider = new OctopusFeatureProvider(new OctopusFeatureConfiguration(clientIdentifier));
+var provider = new OctopusFeatureProvider(new OctopusFeatureConfiguration(clientIdentifier, new ProductMetadata("MyProductName"));
 
 await OpenFeature.Api.Instance.SetProviderAsync(provider);
 


### PR DESCRIPTION
Fixes a couple of errors in the getting-started example to ensure you can copy-paste it and have it compile. 