### PR TITLE
fix: log 'slug did not match' warning once per context

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -1,6 +1,8 @@
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using OpenFeature.Constant;
 using OpenFeature.Model;
 
@@ -422,6 +424,30 @@ public class OctopusFeatureContextTests
     public void GetNormalizedNumber_MatchesExpectedValue(string evaluationKey, string targetingKey, int expected)
     {
         OctopusFeatureContext.GetNormalizedNumber(evaluationKey, targetingKey).Should().Be(expected);
+    }
+
+    [Fact]
+    public void WhenSameMissingSlug_IsEvaluatedRepeatedly_OnlyOneWarningIsLogged()
+    {
+        var featureToggles = new FeatureToggles([
+            new FeatureToggleEvaluation("known-feature", true, "evaluation-key", [], 100)
+        ], []);
+        var fakeLogger = new FakeLogger();
+        var context = new OctopusFeatureContext(featureToggles, new SingleLoggerFactory(fakeLogger));
+
+        for (var i = 0; i < 10; i++)
+        {
+            context.Evaluate("missing-slug", defaultValue: false, context: null);
+        }
+
+        fakeLogger.Collector.GetSnapshot().Should().ContainSingle(r => r.Level == LogLevel.Warning);
+    }
+
+    class SingleLoggerFactory(ILogger logger) : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => logger;
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
     }
 }
 

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Buffers.Binary;
+using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
     public byte[] ContentHash => toggles.ContentHash;
     readonly Regex expression = new("^([a-z0-9]+(-[a-z0-9]+)*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     readonly ILogger logger = loggerFactory.CreateLogger<OctopusFeatureContext>();
+    readonly ConcurrentDictionary<string, byte> warnedSlugs = new(StringComparer.OrdinalIgnoreCase);
 
     public static OctopusFeatureContext Empty(ILoggerFactory loggerFactory)
     {
@@ -36,9 +38,12 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
 
         if (feature == null)
         {
-            logger.LogWarning(
-                "The slug {Slug} did not match any of your Octopus Feature Toggles. Please double check your slug and try again.",
-                slug);
+            if (warnedSlugs.TryAdd(slug, 0))
+            {
+                logger.LogWarning(
+                    "The slug {Slug} did not match any of your Octopus Feature Toggles. Please double check your slug and try again.",
+                    slug);
+            }
 
             return new ResolutionDetails<bool>(slug, defaultValue, ErrorType.FlagNotFound,
                 "The slug provided did not match any of your Octopus Feature Toggles. Please double check your slug and try again.");


### PR DESCRIPTION
## Summary

Reduces log noise from the `"The slug {Slug} did not match..."` warning in `OctopusFeatureContext`, which currently fires on every `Evaluate()` call for an unknown slug.

## Context

Surfaced during an active incident: feature-toggle warnings are dominating logs across the cloud fleet, making triage harder and burning Seq quota. Each process holding a stale reference to a removed or renamed toggle re-emits this warning on every flag evaluation.

## What changed

- Added a per-context `ConcurrentDictionary<string, byte>` (`OrdinalIgnoreCase`) to `OctopusFeatureContext`.
- The warning is now gated by `warnedSlugs.TryAdd(slug, 0)` — the first evaluation of a missing slug against a given context still logs; subsequent evaluations are silent.
- A new `OctopusFeatureContext` is constructed when the manifest content hash changes, so the dedup state resets when something material on the server side actually changes. Genuine recurrences still surface.

The returned `ResolutionDetails<bool>` with `ErrorType.FlagNotFound` is unchanged — callers see the same outcome.

## Expected outcome

In steady state, each missing slug logs at most once per process lifetime (plus once more whenever someone edits a toggle on the server side).

## Why keep it at Warning

Unsure who's actively reading these, but it seems reasonable to keep as a warning — just at a reduced rate.
