### PR TITLE
feat!: Send product metadata in custom header

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Octopus.OpenFeature.Provider.Tests;
+
+public class OctopusFeatureClientTests
+{
+    [Fact]
+    public void AddOctopusClientHeader_SetsXOctopusClientHeader()
+    {
+        var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct"));
+        var client = new OctopusFeatureClient(config, NullLogger.Instance);
+        var httpClient = new HttpClient();
+
+        client.AddOctopusClientHeader(httpClient);
+
+        httpClient.DefaultRequestHeaders.Should().ContainKey("X-Octopus-Client");
+    }
+
+    [Fact]
+    public void AddOctopusClientHeader_WithNameOnly_HeaderContainsProductNameAndProviderInformation()
+    {
+        var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct"));
+        var client = new OctopusFeatureClient(config, NullLogger.Instance);
+        var httpClient = new HttpClient();
+        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version;
+
+        client.AddOctopusClientHeader(httpClient);
+
+        var headerValue = httpClient.DefaultRequestHeaders.GetValues("X-Octopus-Client").Single();
+        headerValue.Should().Be($"MyProduct openfeature-provider-dotnet/{expectedVersion}");
+    }
+
+    [Fact]
+    public void AddOctopusClientHeader_WithNameAndVersion_HeaderContainsProductAndProviderInformation()
+    {
+        var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct", "2024.1.0"));
+        var client = new OctopusFeatureClient(config, NullLogger.Instance);
+        var httpClient = new HttpClient();
+        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version;
+
+        client.AddOctopusClientHeader(httpClient);
+
+        var headerValue = httpClient.DefaultRequestHeaders.GetValues("X-Octopus-Client").Single();
+        headerValue.Should().Be($"MyProduct/2024.1.0 openfeature-provider-dotnet/{expectedVersion}");
+    }
+
+    [Fact]
+    public void AddOctopusClientHeader_WithNameContainingUnsupportedChars_StripsCharsFromHeader()
+    {
+        // Note: More character checking tests are in ProductMetadataTests.cs
+        
+        var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("My Product"));
+        var client = new OctopusFeatureClient(config, NullLogger.Instance);
+        var httpClient = new HttpClient();
+
+        client.AddOctopusClientHeader(httpClient);
+
+        var headerValue = httpClient.DefaultRequestHeaders.GetValues("X-Octopus-Client").Single();
+        headerValue.Should().StartWith("MyProduct ");
+    }
+}

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
@@ -23,7 +23,7 @@ public class OctopusFeatureClientTests
         var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct"));
         var client = new OctopusFeatureClient(config, NullLogger.Instance);
         var httpClient = new HttpClient();
-        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version;
+        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version?.ToString(3);
 
         client.AddOctopusClientHeader(httpClient);
 
@@ -37,7 +37,7 @@ public class OctopusFeatureClientTests
         var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct", "2024.1.0"));
         var client = new OctopusFeatureClient(config, NullLogger.Instance);
         var httpClient = new HttpClient();
-        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version;
+        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version?.ToString(3);
 
         client.AddOctopusClientHeader(httpClient);
 

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
@@ -53,10 +53,11 @@ public class OctopusFeatureClientTests
         var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("My Product"));
         var client = new OctopusFeatureClient(config, NullLogger.Instance);
         var httpClient = new HttpClient();
+        var expectedVersion = typeof(OctopusFeatureClient).Assembly.GetName().Version?.ToString(3);
 
         client.AddOctopusClientHeader(httpClient);
 
         var headerValue = httpClient.DefaultRequestHeaders.GetValues("X-Octopus-Client").Single();
-        headerValue.Should().StartWith("MyProduct ");
+        headerValue.Should().Be($"MyProduct openfeature-provider-dotnet/{expectedVersion}");
     }
 }

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
@@ -49,7 +49,7 @@ public class OctopusFeatureClientTests
     public void AddOctopusClientHeader_WithNameContainingUnsupportedChars_StripsCharsFromHeader()
     {
         // Note: More character checking tests are in ProductMetadataTests.cs
-        
+
         var config = new OctopusFeatureConfiguration("test-id", new ProductMetadata("My Product"));
         var client = new OctopusFeatureClient(config, NullLogger.Instance);
         var httpClient = new HttpClient();

--- a/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
@@ -13,11 +13,20 @@ public class ProductMetadataTests
     }
 
     [Fact]
-    public void CleanProductName_WithUnsupportedChars_StripsThemOut()
+    public void CleanProductName_WithCommonUnsupportedChars_StripsThemOut()
     {
-        var metadata = new ProductMetadata("My Product@2024");
+        // Characters that may be used but are not RFC 9110 tchars
+        var metadata = new ProductMetadata("My ,Product (v2.0)/release@2024:final");
 
-        metadata.CleanProductName.Should().Be("MyProduct2024");
+        metadata.CleanProductName.Should().Be("MyProductv2.0release2024final");
+    }
+
+    [Fact]
+    public void CleanProductName_WithHyphen_PreservesIt()
+    {
+        var metadata = new ProductMetadata("My-Product");
+
+        metadata.CleanProductName.Should().Be("My-Product");
     }
 
     [Fact]

--- a/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
@@ -5,52 +5,52 @@ namespace Octopus.OpenFeature.Provider.Tests;
 public class ProductMetadataTests
 {
     [Fact]
-    public void CleanProductName_WithValidChars_ReturnsNameUnchanged()
+    public void Constructor_WithValidNameChars_SetsNameUnchanged()
     {
         var metadata = new ProductMetadata("OctopusDeploy");
 
-        metadata.CleanProductName.Should().Be("OctopusDeploy");
+        metadata.Name.Should().Be("OctopusDeploy");
     }
 
     [Fact]
-    public void CleanProductName_WithCommonUnsupportedChars_StripsThemOut()
+    public void Constructor_WithCommonUnsupportedCharsInName_StripsThemOut()
     {
         // Characters that may be used but are not RFC 9110 tchars
         var metadata = new ProductMetadata("My ,Product (v2.0)/release@2024:final");
 
-        metadata.CleanProductName.Should().Be("MyProductv2.0release2024final");
+        metadata.Name.Should().Be("MyProductv2.0release2024final");
     }
 
     [Fact]
-    public void CleanProductName_WithHyphen_PreservesIt()
+    public void Constructor_WithHyphenInName_PreservesIt()
     {
         var metadata = new ProductMetadata("My-Product");
 
-        metadata.CleanProductName.Should().Be("My-Product");
+        metadata.Name.Should().Be("My-Product");
     }
 
     [Fact]
-    public void CleanProductVersion_WhenNoVersionProvided_ReturnsNull()
+    public void Constructor_WhenNoVersionProvided_SetsNull()
     {
         var metadata = new ProductMetadata("MyProduct");
 
-        metadata.CleanProductVersion.Should().BeNull();
+        metadata.Version.Should().BeNull();
     }
 
     [Fact]
-    public void CleanProductVersion_WithValidChars_ReturnsVersionUnchanged()
+    public void Constructor_WithValidCharsInVersion_SetsVersionUnchanged()
     {
         var metadata = new ProductMetadata("MyProduct", "2024.1.0");
 
-        metadata.CleanProductVersion.Should().Be("2024.1.0");
+        metadata.Version.Should().Be("2024.1.0");
     }
 
     [Fact]
-    public void CleanProductVersion_WithUnsupportedChars_StripsThemOut()
+    public void Constructor_WithUnsupportedCharsInVersion_StripsThemOut()
     {
         var metadata = new ProductMetadata("MyProduct", "2024.1 (beta)");
 
-        metadata.CleanProductVersion.Should().Be("2024.1beta");
+        metadata.Version.Should().Be("2024.1beta");
     }
 
     [Fact]

--- a/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/ProductMetadataTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+
+namespace Octopus.OpenFeature.Provider.Tests;
+
+public class ProductMetadataTests
+{
+    [Fact]
+    public void CleanProductName_WithValidChars_ReturnsNameUnchanged()
+    {
+        var metadata = new ProductMetadata("OctopusDeploy");
+
+        metadata.CleanProductName.Should().Be("OctopusDeploy");
+    }
+
+    [Fact]
+    public void CleanProductName_WithUnsupportedChars_StripsThemOut()
+    {
+        var metadata = new ProductMetadata("My Product@2024");
+
+        metadata.CleanProductName.Should().Be("MyProduct2024");
+    }
+
+    [Fact]
+    public void CleanProductVersion_WhenNoVersionProvided_ReturnsNull()
+    {
+        var metadata = new ProductMetadata("MyProduct");
+
+        metadata.CleanProductVersion.Should().BeNull();
+    }
+
+    [Fact]
+    public void CleanProductVersion_WithValidChars_ReturnsVersionUnchanged()
+    {
+        var metadata = new ProductMetadata("MyProduct", "2024.1.0");
+
+        metadata.CleanProductVersion.Should().Be("2024.1.0");
+    }
+
+    [Fact]
+    public void CleanProductVersion_WithUnsupportedChars_StripsThemOut()
+    {
+        var metadata = new ProductMetadata("MyProduct", "2024.1 (beta)");
+
+        metadata.CleanProductVersion.Should().Be("2024.1beta");
+    }
+
+    [Fact]
+    public void Constructor_WhenNameBecomesEmptyAfterCleaning_ThrowsArgumentException()
+    {
+        var act = () => new ProductMetadata("   ");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Product name*");
+    }
+
+    [Fact]
+    public void Constructor_WhenVersionBecomesEmptyAfterCleaning_ThrowsArgumentException()
+    {
+        var act = () => new ProductMetadata("MyProduct", "   ");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Product version*");
+    }
+}

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -76,14 +76,16 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
     internal void AddOctopusClientHeader(HttpClient client)
     {
         var clientHeaderValueBuilder = new StringBuilder(configuration.ProductMetadata.CleanProductName);
-        
-        if(!String.IsNullOrWhiteSpace(configuration.ProductMetadata.CleanProductVersion))
+
+        if (!String.IsNullOrWhiteSpace(configuration.ProductMetadata.CleanProductVersion))
         {
             clientHeaderValueBuilder.Append($"/{configuration.ProductMetadata.CleanProductVersion}");
         }
 
-        clientHeaderValueBuilder.Append($" openfeature-provider-dotnet/{typeof(OctopusFeatureClient).Assembly.GetName().Version}");
-        
+        clientHeaderValueBuilder.Append(
+            $" openfeature-provider-dotnet/{typeof(OctopusFeatureClient).Assembly.GetName().Version.ToString(3)}"
+        );
+
         client.DefaultRequestHeaders.Add("X-Octopus-Client", clientHeaderValueBuilder.ToString());
     }
 

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -129,12 +129,14 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
             logger.LogWarning("Feature toggle response from {OctoToggleUrl} did not contain expected ContentHash header", configuration.ServerUri);
             return null;
         }
+
         var headerValues = values.ToArray();
         if (!headerValues.Any())
         {
             logger.LogWarning("Feature toggle response from {OctoToggleUrl} returned an empty ContentHash header", configuration.ServerUri);
             return null;
         }
+
         var rawContentHash = headerValues.First();
 
         // WARNING: v2 and v3 endpoints have identical response contracts.

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -48,7 +48,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         {
             BaseAddress = configuration.ServerUri
         };
-        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(configuration.ProductMetadata.ProductHeaderValue));
+        AddOctopusClientHeader(client);
 
         FeatureCheck? hash = null;
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
@@ -73,6 +73,20 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         return haveFeaturesChanged;
     }
 
+    internal void AddOctopusClientHeader(HttpClient client)
+    {
+        var clientHeaderValueBuilder = new StringBuilder(configuration.ProductMetadata.CleanProductName);
+        
+        if(!String.IsNullOrWhiteSpace(configuration.ProductMetadata.CleanProductVersion))
+        {
+            clientHeaderValueBuilder.Append($"/{configuration.ProductMetadata.CleanProductVersion}");
+        }
+
+        clientHeaderValueBuilder.Append($" openfeature-provider-dotnet/{typeof(OctopusFeatureClient).Assembly.GetName().Version}");
+        
+        client.DefaultRequestHeaders.Add("X-Octopus-Client", clientHeaderValueBuilder.ToString());
+    }
+
     class FeatureCheck(byte[] contentHash)
     {
         public byte[] ContentHash { get; } = contentHash;
@@ -91,7 +105,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         {
             BaseAddress = configuration.ServerUri
         };
-        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(configuration.ProductMetadata.ProductHeaderValue));
+        AddOctopusClientHeader(client);
 
         if (configuration.ReleaseVersionOverride is not null)
         {

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -77,13 +77,13 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
     {
         var clientHeaderValueBuilder = new StringBuilder(configuration.ProductMetadata.CleanProductName);
 
-        if (!String.IsNullOrWhiteSpace(configuration.ProductMetadata.CleanProductVersion))
+        if (configuration.ProductMetadata.CleanProductVersion is not null)
         {
             clientHeaderValueBuilder.Append($"/{configuration.ProductMetadata.CleanProductVersion}");
         }
 
         clientHeaderValueBuilder.Append(
-            $" openfeature-provider-dotnet/{typeof(OctopusFeatureClient).Assembly.GetName().Version.ToString(3)}"
+            $" openfeature-provider-dotnet/{typeof(OctopusFeatureClient).Assembly.GetName().Version?.ToString(3)}"
         );
 
         client.DefaultRequestHeaders.Add("X-Octopus-Client", clientHeaderValueBuilder.ToString());

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -75,11 +75,11 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
     internal void AddOctopusClientHeader(HttpClient client)
     {
-        var clientHeaderValueBuilder = new StringBuilder(configuration.ProductMetadata.CleanProductName);
+        var clientHeaderValueBuilder = new StringBuilder(configuration.ProductMetadata.Name);
 
-        if (configuration.ProductMetadata.CleanProductVersion is not null)
+        if (configuration.ProductMetadata.Version is not null)
         {
-            clientHeaderValueBuilder.Append($"/{configuration.ProductMetadata.CleanProductVersion}");
+            clientHeaderValueBuilder.Append($"/{configuration.ProductMetadata.Version}");
         }
 
         clientHeaderValueBuilder.Append(

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
@@ -17,7 +17,7 @@ public class OctopusFeatureProvider : FeatureProvider
 
     public override Metadata GetMetadata()
     {
-        return new Metadata("octopus-feature");
+        return new Metadata("octopus-dotnet-provider");
     }
 
     public override async Task InitializeAsync(EvaluationContext context, CancellationToken cancellationToken = new())

--- a/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
+++ b/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
@@ -11,49 +11,48 @@ public class ProductMetadata
     // https://www.rfc-editor.org/rfc/rfc9110.html#name-tokens
     private static readonly Regex UnsupportedChars = new("[^a-zA-Z0-9!#$%&'*+\\-.^_`|~]", RegexOptions.Compiled);
 
-    private string ProductName { get; }
-    private string? ProductVersion { get; }
-
-    internal string CleanProductName => UnsupportedChars.Replace(ProductName, "");
-    internal string? CleanProductVersion => ProductVersion == null ? null : UnsupportedChars.Replace(ProductVersion, "");
+    public string Name { get; }
+    public string? Version { get; }
 
     /// <summary>
-    /// Construct a ProductMetadata with the product name only
+    /// Construct a ProductMetadata with the product name only.
     /// </summary>
-    /// <param name="productName">The name of the product</param>
-    public ProductMetadata(string productName)
+    /// <param name="name">The name of the product. Unsupported characters will be removed.</param>
+    public ProductMetadata(string name)
     {
-        ProductName = productName;
-        ProductVersion = null;
+        Name = Clean(name);
+        Version = null;
 
-        ValidateProductName();
+        ValidateName();
     }
 
     /// <summary>
-    /// Construct a ProductMetadata with the product name and version
+    /// Construct a ProductMetadata with the product name and version.
     /// </summary>
-    /// <param name="productName">The name of the product</param>
-    /// <param name="productVersion">The version of the product</param>
-    public ProductMetadata(string productName, string productVersion)
+    /// <param name="name">The name of the product. Unsupported characters will be removed.</param>
+    /// <param name="version">The version of the product. Unsupported characters will be removed.</param>
+    public ProductMetadata(string name, string version)
     {
-        ProductName = productName;
-        ProductVersion = productVersion;
+        Name = Clean(name);
+        Version = Clean(version);
 
-        ValidateProductName();
-        ValidateProductVersion();
+        ValidateName();
+        ValidateVersion();
     }
 
-    private void ValidateProductName()
+    private static string Clean(string value) => UnsupportedChars.Replace(value, "");
+
+    private void ValidateName()
     {
-        if (CleanProductName.Length == 0)
+        if (Name.Length == 0)
         {
             throw new ArgumentException("Product name must contain at least one valid token character.");
         }
     }
 
-    private void ValidateProductVersion()
+    private void ValidateVersion()
     {
-        if (CleanProductVersion?.Length == 0)
+        if (Version?.Length == 0)
         {
             throw new ArgumentException("Product version must contain at least one valid token character.");
         }

--- a/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
+++ b/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
@@ -1,24 +1,55 @@
-using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
 
 namespace Octopus.OpenFeature.Provider;
 
 /// <summary>
-/// Metadata about the application using the OpenFeature provider. Used to build 
-/// the User-Agent sent in HTTP requests.
+/// Metadata about the application using the OpenFeature provider.
+/// Used to populate header for telemetry.
 /// </summary>
-/// <param name="productName">The name of the product</param>
-/// <param name="productVersion">The version of the product</param>
 public class ProductMetadata
 {
+    // https://www.rfc-editor.org/rfc/rfc9110.html#name-tokens
+    private static readonly Regex UnsupportedChars = new("[^a-zA-Z0-9!#$%&'*+-.^_`|~]", RegexOptions.Compiled);
+
+    private string ProductName { get; }
+    private string? ProductVersion { get; }
+
+    internal string CleanProductName => UnsupportedChars.Replace(ProductName, "");
+    internal string? CleanProductVersion => ProductVersion == null ? null : UnsupportedChars.Replace(ProductVersion, "");
+
+    /// <summary>
+    /// Construct a ProductMetadata with the product name only
+    /// </summary>
+    /// <param name="productName">The name of the product</param>
     public ProductMetadata(string productName)
     {
-        ProductHeaderValue = new ProductHeaderValue(productName);
+        ProductName = productName;
+        ProductVersion = null;
+
+        if (CleanProductName.Length == 0)
+        {
+            throw new ArgumentException("Product name must contain at least one valid token character.");
+        }
     }
 
+    /// <summary>
+    /// Construct a ProductMetadata with the product name and version
+    /// </summary>
+    /// <param name="productName">The name of the product</param>
+    /// <param name="productVersion">The version of the product</param>
     public ProductMetadata(string productName, string productVersion)
     {
-        ProductHeaderValue = new ProductHeaderValue(productName, productVersion);
-    }
+        ProductName = productName;
+        ProductVersion = productVersion;
 
-    public ProductHeaderValue ProductHeaderValue { get; }
+        if (CleanProductName.Length == 0)
+        {
+            throw new ArgumentException("Product name must contain at least one valid token character.");
+        }
+
+        if (CleanProductVersion?.Length == 0)
+        {
+            throw new ArgumentException("Product version must contain at least one valid token character.");
+        }
+    }
 }

--- a/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
+++ b/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
@@ -26,10 +26,7 @@ public class ProductMetadata
         ProductName = productName;
         ProductVersion = null;
 
-        if (CleanProductName.Length == 0)
-        {
-            throw new ArgumentException("Product name must contain at least one valid token character.");
-        }
+        ValidateProductName();
     }
 
     /// <summary>
@@ -42,11 +39,20 @@ public class ProductMetadata
         ProductName = productName;
         ProductVersion = productVersion;
 
+        ValidateProductName();
+        ValidateProductVersion();
+    }
+
+    private void ValidateProductName()
+    {
         if (CleanProductName.Length == 0)
         {
             throw new ArgumentException("Product name must contain at least one valid token character.");
         }
+    }
 
+    private void ValidateProductVersion()
+    {
         if (CleanProductVersion?.Length == 0)
         {
             throw new ArgumentException("Product version must contain at least one valid token character.");

--- a/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
+++ b/src/Octopus.OpenFeature.Provider/ProductMetadata.cs
@@ -9,7 +9,7 @@ namespace Octopus.OpenFeature.Provider;
 public class ProductMetadata
 {
     // https://www.rfc-editor.org/rfc/rfc9110.html#name-tokens
-    private static readonly Regex UnsupportedChars = new("[^a-zA-Z0-9!#$%&'*+-.^_`|~]", RegexOptions.Compiled);
+    private static readonly Regex UnsupportedChars = new("[^a-zA-Z0-9!#$%&'*+\\-.^_`|~]", RegexOptions.Compiled);
 
     private string ProductName { get; }
     private string? ProductVersion { get; }


### PR DESCRIPTION
# Background

We want to be able to observe the usage of the OctoToggle service and its different API endpoints over time. For example, if we wish to deprecate an endpoint or know which customers are using a particular version of a provider library.

This library is already sending product metadata in a User Agent header, however this approach is not able to be applied to all our provider libraries and we want consistency between them.

# Changes

* Replaced `User-Agent` header with `X-Octopus-Client` header.
  * The value of this header is constructed by use and contains:
    * Consumer provided product name.
    * Optionally: consumer provided product version.
    * Hard coded provider library repo name.
    * The provider library's assembly version number (to three components).
  * e.g. `MyProduct/2024.1.0 openfeature-provider-dotnet/2.1.0`
* Replaced use of [`System.Net.Http.Headers.ProductInfoHeaderValue`](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.headers.productinfoheadervalue?view=netstandard-2.0) with custom value handling.
  * This is now more lenient where we now validate only that at least one valid character (per [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-tokens)) is provided for the product name and the version (if provided). Any invalid characters are silently stripped out.

# Testing

In addition to automated tests, I have tested against a OctoToggle ephemeral environment which attaches the raw `X-Octopus-Client` header value to the top level span. The actual OctoToggle changes will split the value up into component fields (i.e. separate fields for product name, product version, library name and library version). Ideally, we should implement those changes before merging this PR so that we are not hindered from releasing without losing telemetry data.

<img width="1525" height="516" alt="image" src="https://github.com/user-attachments/assets/57cf1a66-54a7-473f-b499-089870f80888" />
<img width="1525" height="496" alt="image" src="https://github.com/user-attachments/assets/4e1af35d-de95-4bcf-b51b-b561d66960b8" />

# Notes for review

* The removal of `public ProductHeaderValue ProductHeaderValue` from `ProductMetadata` makes this a breaking change. Ideally this would have been `internal`.