### PR TITLE
fix: Simplify logic for refresh and retry

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
@@ -131,6 +131,84 @@ public class OctopusFeatureContextProviderTests
         }
     }
 
+    [Fact]
+    public async Task WhenInitialFetchReturnsNothing_AndRefreshSucceeds_ContextIsPopulated()
+    {
+        var logger = new FakeLogger();
+
+        byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
+
+        // Initialize with a null client so that initial fetch fails
+        var client = new MockOctopusFeatureClient(null);
+
+        var provider = new OctopusFeatureContextProvider(configuration, client, logger);
+        await provider.Initialize();
+
+        // Assert that initial fetch failure is logged and context is empty
+         using var scope = new AssertionScope();
+        provider.GetEvaluationContext().ContentHash.Length.Should().Be(0);
+        logger.LatestRecord.Message.Should().StartWith("Failed to retrieve feature manifest during initialization");
+
+        // Update client to return valid toggles and wait for refresh
+        client.ChangeToggles(new FeatureToggles(
+            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
+            contentHash));
+        await Task.Delay(TimeSpan.FromSeconds(3));
+
+        try
+        {
+            // Assert that the context is now correctly populated
+            var context = provider.GetEvaluationContext();
+            context.ContentHash.Should().BeEquivalentTo(contentHash);
+        }
+        finally
+        {
+            await provider.Shutdown();
+        }
+    }
+
+    [Fact]
+    public async Task WhenRefreshReturnsNothing_AndSubsequentRefreshSucceeds_ContextIsUpdated()
+    {
+        var logger = new FakeLogger();
+
+        byte[] initialHash = [0x01, 0x02, 0x03, 0x04];
+        byte[] updatedHash = [0x01, 0x02, 0x03, 0x05];
+
+        // Start with a client that returns valid toggles
+        var client = new MockOctopusFeatureClient(new FeatureToggles(
+            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
+            initialHash));
+
+        var provider = new OctopusFeatureContextProvider(configuration, client, logger);
+        await provider.Initialize();
+
+        try
+        {
+            // Switch to a null client and wait for refresh to fail
+            client.ChangeToggles(null);
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Assert that failed refresh is logged and old context is retained
+            logger.LatestRecord.Message.Should().StartWith("Failed to retrieve updated feature manifest");
+            provider.GetEvaluationContext().ContentHash.Should().BeEquivalentTo(initialHash);
+
+            // Update client to return valid toggles again and wait for refresh
+            client.ChangeToggles(new FeatureToggles(
+                [new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)],
+                updatedHash));
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Assert that the context is now correctly populated
+            var context = provider.GetEvaluationContext();
+            context.ContentHash.Should().BeEquivalentTo(updatedHash);
+        }
+        finally
+        {
+            await provider.Shutdown();
+        }
+    }
+
     class AlwaysFailsFeatureClient : IOctopusFeatureClient
     {
         public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
@@ -164,7 +164,7 @@ public class OctopusFeatureContextProviderTests
     class ThrowsOnRefreshClient(FeatureToggles initial) : IOctopusFeatureClient
     {
         public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
-        { 
+        {
             throw new Exception("Oops! Simulated error.");
         }
 

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
@@ -138,28 +138,22 @@ public class OctopusFeatureContextProviderTests
 
         byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
 
-        // Initialize with a null client so that initial fetch fails
+        // Initialize with a null client so that first fetch fails
         var client = new MockOctopusFeatureClient(null);
-
         var provider = new OctopusFeatureContextProvider(configuration, client, logger);
         await provider.Initialize();
 
-        // Assert that initial fetch failure is logged and context is empty
-         using var scope = new AssertionScope();
-        provider.GetEvaluationContext().ContentHash.Length.Should().Be(0);
-        logger.LatestRecord.Message.Should().StartWith("Failed to retrieve feature manifest during initialization");
-
-        // Update client to return valid toggles and wait for refresh
-        client.ChangeToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            contentHash));
-        await Task.Delay(TimeSpan.FromSeconds(3));
-
         try
         {
+            // Check that the context is empty
+            provider.GetEvaluationContext().ContentHash.Length.Should().Be(0);
+
+            // Update client to return valid toggles and wait for refresh
+            client.ChangeToggles(new FeatureToggles([new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)], contentHash));
+            await Task.Delay(TimeSpan.FromSeconds(5));
+
             // Assert that the context is now correctly populated
-            var context = provider.GetEvaluationContext();
-            context.ContentHash.Should().BeEquivalentTo(contentHash);
+            provider.GetEvaluationContext().ContentHash.Should().BeEquivalentTo(contentHash);
         }
         finally
         {
@@ -175,11 +169,8 @@ public class OctopusFeatureContextProviderTests
         byte[] initialHash = [0x01, 0x02, 0x03, 0x04];
         byte[] updatedHash = [0x01, 0x02, 0x03, 0x05];
 
-        // Start with a client that returns valid toggles
-        var client = new MockOctopusFeatureClient(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            initialHash));
-
+        // Initialize with a client that returns valid toggles
+        var client = new MockOctopusFeatureClient(new FeatureToggles([new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)], initialHash));
         var provider = new OctopusFeatureContextProvider(configuration, client, logger);
         await provider.Initialize();
 
@@ -187,21 +178,64 @@ public class OctopusFeatureContextProviderTests
         {
             // Switch to a null client and wait for refresh to fail
             client.ChangeToggles(null);
-            await Task.Delay(TimeSpan.FromSeconds(3));
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert that failed refresh is logged and old context is retained
             logger.LatestRecord.Message.Should().StartWith("Failed to retrieve updated feature manifest");
             provider.GetEvaluationContext().ContentHash.Should().BeEquivalentTo(initialHash);
 
             // Update client to return valid toggles again and wait for refresh
-            client.ChangeToggles(new FeatureToggles(
-                [new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)],
-                updatedHash));
-            await Task.Delay(TimeSpan.FromSeconds(3));
+            client.ChangeToggles(new FeatureToggles([new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)], updatedHash));
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert that the context is now correctly populated
             var context = provider.GetEvaluationContext();
             context.ContentHash.Should().BeEquivalentTo(updatedHash);
+        }
+        finally
+        {
+            await provider.Shutdown();
+        }
+    }
+
+    class ThrowsOnRefreshClient(FeatureToggles initial) : IOctopusFeatureClient
+    {
+        public readonly string ErrorMessage = "Oops! Simulated refresh error";
+
+        public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
+        {
+            throw new Exception(ErrorMessage);
+        }
+
+        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<FeatureToggles?>(initial);
+        }
+    }
+
+    [Fact]
+    public async Task WhenAnExceptionIsThrownDuringRefresh_LogsErrorDetails()
+    {
+        byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
+        var logger = new FakeLogger();
+
+        // Initialize with a client that will throw on refresh
+        var client = new ThrowsOnRefreshClient(
+            new FeatureToggles([new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)], contentHash)
+        );
+        var provider = new OctopusFeatureContextProvider(configuration, client, logger);
+        await provider.Initialize();
+
+        // Wait for cache to clear and refresh attempt to occur
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            logger.Collector.GetSnapshot()
+                .Should().Contain(r => r.Message.Contains("Failed to retrieve updated feature manifest")
+                    && r.Exception != null
+                    && r.Exception.Message.Contains(client.ErrorMessage)
+                );
         }
         finally
         {
@@ -237,48 +271,5 @@ public class OctopusFeatureContextProviderTests
         logger.LatestRecord.Message.Should().StartWith("Failed to retrieve feature manifest");
 
         await provider.Shutdown();
-    }
-
-    class ThrowsOnRefreshClient(FeatureToggles initial) : IOctopusFeatureClient
-    {
-        public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
-        {
-            throw new Exception("Oops! Simulated error.");
-        }
-
-        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
-        {
-            return Task.FromResult<FeatureToggles?>(initial);
-        }
-    }
-
-    [Fact]
-    public async Task WhenRefreshThrowsException_LogsRetryAttemptDetails()
-    {
-        byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
-        var logger = new FakeLogger();
-
-        var client = new ThrowsOnRefreshClient(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            contentHash));
-
-        var provider = new OctopusFeatureContextProvider(configuration, client, logger);
-        await provider.Initialize();
-
-        // Wait for cache to clear and refresh attempt to occur
-        await Task.Delay(TimeSpan.FromSeconds(5));
-
-        try
-        {
-            logger.Collector.GetSnapshot()
-                .Should().Contain(r => r.Message.Contains("Failed to retrieve feature manifest") && r.Message.Contains("Trying again after"));
-
-            var context = provider.GetEvaluationContext();
-            context.ContentHash.Should().BeEquivalentTo(contentHash);
-        }
-        finally
-        {
-            await provider.Shutdown();
-        }
     }
 }

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
@@ -160,4 +160,47 @@ public class OctopusFeatureContextProviderTests
 
         await provider.Shutdown();
     }
+
+    class ThrowsOnRefreshClient(FeatureToggles initial) : IOctopusFeatureClient
+    {
+        public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
+        { 
+            throw new Exception("Oops! Simulated error.");
+        }
+
+        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+        {
+            return Task.FromResult<FeatureToggles?>(initial);
+        }
+    }
+
+    [Fact]
+    public async Task WhenRefreshThrowsException_LogsRetryAttemptDetails()
+    {
+        byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
+        var logger = new FakeLogger();
+
+        var client = new ThrowsOnRefreshClient(new FeatureToggles(
+            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
+            contentHash));
+
+        var provider = new OctopusFeatureContextProvider(configuration, client, logger);
+        await provider.Initialize();
+
+        // Wait for cache to clear and refresh attempt to occur
+        await Task.Delay(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            logger.Collector.GetSnapshot()
+                .Should().Contain(r => r.Message.Contains("Failed to retrieve feature manifest") && r.Message.Contains("Trying again after"));
+
+            var context = provider.GetEvaluationContext();
+            context.ContentHash.Should().BeEquivalentTo(contentHash);
+        }
+        finally
+        {
+            await provider.Shutdown();
+        }
+    }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -167,6 +167,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         {
             logger.LogTrace(e, "Error occurred retrieving feature toggles from {OctoToggleUrl}.", configuration.ServerUri);
         }
+
         return default;
     }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -53,7 +53,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         FeatureCheck? hash = null;
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var result = await Execute(async ct => await client.GetAsync("api/featuretoggles/check/v3/", ct), cancellationToken);
+        var result = await client.GetAsync("api/featuretoggles/check/v3/", cancellationToken);
 
         if (result is not null && result.IsSuccessStatusCode)
         {
@@ -116,7 +116,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var response = await Execute(async ct => await client.GetAsync("api/toggles/evaluations/v3/", ct), cancellationToken);
+        var response = await client.GetAsync("api/toggles/evaluations/v3/", cancellationToken);
 
         if (response is null or { StatusCode: HttpStatusCode.NotFound })
         {
@@ -155,19 +155,5 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         var toggles = new FeatureToggles(evaluations, Convert.FromBase64String(rawContentHash));
 
         return toggles;
-    }
-
-    async Task<T?> Execute<T>(Func<CancellationToken, Task<T>> callback, CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await callback(cancellationToken);
-        }
-        catch (Exception e)
-        {
-            logger.LogTrace(e, "Error occurred retrieving feature toggles from {OctoToggleUrl}.", configuration.ServerUri);
-        }
-
-        return default;
     }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -64,8 +64,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         if (hash is null)
         {
-            logger.LogWarning("Failed to retrieve feature toggles. Previously retrieved feature toggle values will continue to be used.");
-            return false;
+            throw new InvalidOperationException($"Failed to retrieve feature toggles for client identifier. Check did not return a valid content hash.");
         }
 
         var haveFeaturesChanged = !hash.ContentHash.SequenceEqual(contentHash);

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -55,7 +55,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         var result = await client.GetAsync("api/featuretoggles/check/v3/", cancellationToken);
 
-        if (result is not null && result.IsSuccessStatusCode)
+        if (result.IsSuccessStatusCode)
         {
             var rawResult = await result.Content.ReadAsStringAsync();
 
@@ -117,7 +117,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         var response = await client.GetAsync("api/toggles/evaluations/v3/", cancellationToken);
 
-        if (response is null or { StatusCode: HttpStatusCode.NotFound })
+        if (response.StatusCode == HttpStatusCode.NotFound)
         {
             logger.LogWarning("Failed to retrieve feature toggles for client identifier {ClientIdentifier} from {OctoToggleUrl}", configuration.ClientIdentifier, configuration.ServerUri);
             return null;

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -53,7 +53,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         FeatureCheck? hash = null;
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var result = await ExecuteWithRetry(async ct => await client.GetAsync("api/featuretoggles/check/v3/", ct), cancellationToken);
+        var result = await Execute(async ct => await client.GetAsync("api/featuretoggles/check/v3/", ct), cancellationToken);
 
         if (result is not null && result.IsSuccessStatusCode)
         {
@@ -64,7 +64,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         if (hash is null)
         {
-            logger.LogWarning("Failed to retrieve feature toggles after 3 retries. Previously retrieved feature toggle values will continue to be used.");
+            logger.LogWarning("Failed to retrieve feature toggles. Previously retrieved feature toggle values will continue to be used.");
             return false;
         }
 
@@ -116,7 +116,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var response = await ExecuteWithRetry(async ct => await client.GetAsync("api/toggles/evaluations/v3/", ct), cancellationToken);
+        var response = await Execute(async ct => await client.GetAsync("api/toggles/evaluations/v3/", ct), cancellationToken);
 
         if (response is null or { StatusCode: HttpStatusCode.NotFound })
         {
@@ -157,23 +157,16 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         return toggles;
     }
 
-    async Task<T?> ExecuteWithRetry<T>(Func<CancellationToken, Task<T>> callback, CancellationToken cancellationToken)
+    async Task<T?> Execute<T>(Func<CancellationToken, Task<T>> callback, CancellationToken cancellationToken)
     {
-        var attempts = 0;
-        while (attempts < 3)
+        try
         {
-            try
-            {
-                return await callback(cancellationToken);
-            }
-            catch (Exception e)
-            {
-                attempts++;
-                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, attempts)), cancellationToken);
-                logger.LogTrace(e, "Error occurred retrieving feature toggles from {OctoToggleUrl}. Retrying (attempt {attempt} out of 3).", configuration.ServerUri, attempts);
-            }
+            return await callback(cancellationToken);
         }
-
+        catch (Exception e)
+        {
+            logger.LogTrace(e, "Error occurred retrieving feature toggles from {OctoToggleUrl}.", configuration.ServerUri);
+        }
         return default;
     }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
@@ -15,8 +15,6 @@ class OctopusFeatureContextProvider(
     OctopusFeatureContext currentContext = OctopusFeatureContext.Empty(configuration.LoggerFactory);
     Task? evaluationContextRefreshTask;
     bool initialized;
-    int retryAttempt;
-    readonly TimeSpan retryDelay = TimeSpan.FromSeconds(5);
 
     public OctopusFeatureContext GetEvaluationContext()
     {
@@ -55,12 +53,11 @@ class OctopusFeatureContextProvider(
     /// </summary>
     async Task RefreshEvaluationContext(CancellationToken cancellationToken)
     {
-        var delay = configuration.CacheDuration;
         while (!cancellationToken.IsCancellationRequested)
         {
             try
             {
-                await Task.Delay(delay, cancellationToken);
+                await Task.Delay(configuration.CacheDuration, cancellationToken);
 
                 if (await client.HaveFeaturesChanged(currentContext.ContentHash, cancellationToken))
                 {
@@ -74,9 +71,6 @@ class OctopusFeatureContextProvider(
                         logger.LogError("Failed to retrieve updated feature manifest. Retaining existing context which may be stale.");
                     }
                 }
-
-                delay = configuration.CacheDuration;
-                retryAttempt = 0;
             }
             catch (OperationCanceledException)
             {
@@ -84,8 +78,7 @@ class OctopusFeatureContextProvider(
             }
             catch (Exception e)
             {
-                logger.LogError(e, "{FailedMessage}, attempt {RetryAttempt}. Trying again after {Delay}...", "Failed to retrieve feature manifest", retryAttempt, delay);
-                retryAttempt++;
+                logger.LogError(e, "Failed to retrieve updated feature manifest. Retaining existing context which may be stale.");
             }
         }
     }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
@@ -85,7 +85,6 @@ class OctopusFeatureContextProvider(
             catch (Exception e)
             {
                 logger.LogError(e, "{FailedMessage}, attempt {RetryAttempt}. Trying again after {Delay}...", "Failed to retrieve feature manifest", retryAttempt, delay);
-                delay = retryDelay;
                 retryAttempt++;
             }
         }


### PR DESCRIPTION
## Background 🌇

The feature toggle evaluation manifest is fetched when a provider is initialized and then refreshed regularly according to a cache interval. If one of these fetches fails, we have two refresh/retry mechanisms in place, which could significantly increase load on OctoToggle in the event of an outage.  
- RefreshEvaluationContext() drops the refresh interval from the configured cache interval (default 60s) down to a 5-second retry loop
- ExecuteWithRetry() retries each failed HTTP call up to 3 times with exponential backoff.

In [DEVEX-41](https://linear.app/octopus/issue/DEVEX-41/failed-requests-should-not-reset-the-toggle-states), we added logic to fall back the most recent set of evaluations in the case where a refresh fails, rather than falling back to default toggle states. This made waiting the cache duration for a refresh (rather than frantically retrying) a more acceptable option. 

## What's this? 🐦

The PR removes the retry and fast-refresh logic
☑️ `OctopusFeatureContextProvider` - Now instead of dropping down to a five second refresh interval on failure, we just carry on refreshing at the caching interval.  
☑️ `OctopusFeatureClient`  - We've removed the "Retry" from `ExecuteWithRetry`. Now if a call to get the manifest fails, we just wait the cache duration and try again.  

## Testing 🧪
✅ I've given these changes a manual test with both the Functions and ASP.NET OctoToggle setup
✅ The updated **refresh** logic has has been tested using the tests added in this PR. 
❌ No tests show that **retry** logic is removed. 

## How to review? 🔍
💬 Check out the comments on the code
☑️ Code quality
🧪 Any need for more tests?

Part of DEVEX-84