### PR TITLE
fix: Remove slug formatting check from flag evaluation

### DIFF
--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -1,7 +1,6 @@
 ﻿using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Text;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Murmur;
 using OpenFeature.Constant;
@@ -12,7 +11,6 @@ namespace Octopus.OpenFeature.Provider;
 partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory loggerFactory)
 {
     public byte[] ContentHash => toggles.ContentHash;
-    readonly Regex expression = new("^([a-z0-9]+(-[a-z0-9]+)*)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
     readonly ILogger logger = loggerFactory.CreateLogger<OctopusFeatureContext>();
     readonly ConcurrentDictionary<string, byte> warnedSlugs = new(StringComparer.OrdinalIgnoreCase);
 
@@ -23,16 +21,6 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
 
     public ResolutionDetails<bool> Evaluate(string slug, bool defaultValue, EvaluationContext? context)
     {
-        if (expression.IsMatch(slug) == false)
-        {
-            logger.LogWarning(
-                "Flag key {FlagKey} does not appear to be a slug. Please ensure to provide the slug associated with your Octopus Feature Toggle.",
-                slug);
-
-            return new ResolutionDetails<bool>(slug, defaultValue, ErrorType.FlagNotFound,
-                "Flag key provided was not a slug. Please ensure to provide the slug associated with your Octopus Feature Toggle.");
-        }
-
         var feature =
             toggles.Evaluations.FirstOrDefault(x => x.Slug.Equals(slug, StringComparison.OrdinalIgnoreCase));
 


### PR DESCRIPTION
## Background 🌇

At the moment when a wrongly formatted slug is submitted for evaluation by the .NET provider, we catch it before attempting to look up the toggle in the manifest, and return a FLAG_NOT_FOUND error with a message about invalid formatting. There is no equivalent check in the Java provider. 

## What's this? 🐦 

This change removes the formatting check and falls back to just checking for the wrongly formatted slug like we would for any other slug. If the slug doesn't match any slug in the manifest, regardless of formatting, our existing code paths return a FLAG_NOT_FOUND with an error message that the slug could not be matched. 

## Testing 🧪 

This has been tested manually with some correctly and incorrectly formatted slugs.

## How to review? 🔍 
🧪 Any additional thoughts on testing?

Part of DEVEX-255