### PR TITLE
docs: Add documentation for releasing the provider library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # all
           submodules: 'true'
 
       - name: Build, Test, Pack, and Deploy (CI)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # all
           submodules: 'true'
 
       - name: Build, Test, Pack, and Deploy (Release)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,6 @@
 # Releasing
 
-Versioning and publishing are automated — there is no manual version bump and no hand-cut GitHub
-release. Release Please owns the version and changelog; GitHub Actions builds, tests, and packs the
-package; and Octopus Deploy publishes release versions to nuget.org.
-
-This repo is the reference the Java and TS providers converge on (see DEVEX-318).
+Versioning and publishing are automated. Release Please owns the version and changelog; GitHub Actions builds, tests, and packs the package; and Octopus Deploy publishes release versions to nuget.org.
 
 ## Pipeline
 
@@ -32,19 +28,14 @@ flowchart TD
     class OCT oct;
 ```
 
-- **Prerelease builds** — pushes to `main` (`ci`), PRs (`pr.<number>.<branch>`), and the nightly
-  schedule — are also handed to Octopus Deploy, but their versions stay internal and are not
-  published to nuget.org. `--version-suffix` moves the package version (and
-  `AssemblyInformationalVersion`); `AssemblyVersion`/`FileVersion` stay at the release base.
-- **Release builds** run only after a Release Please PR is merged; the packaged artifact is handed to
-  Octopus Deploy, from which the release version is published to nuget.org by a manual action.
+- **Release builds** run after a Release Please PR is merged; the packaged artifact is pushed to Octopus Deploy, from which the release version is published to nuget.org by a manual action.
+- **Prerelease builds** run on pushes to `main`, the nightly schedule, and manual dispatches (all tagged `ci`), and PRs (`pr.<number>.<branch>`). These are pushed to Octopus Deploy and stay internal, except for fork PRs and Dependabot branches, which upload the bundle as a GitHub Actions artifact instead.
+
 
 ## Cutting a release
 
-1. Land changes on `main` using [conventional commits](https://www.conventionalcommits.org/)
-   (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major).
-2. Release Please opens a **release PR** that bumps the version and updates the changelog.
-3. Merge the release PR. The tag, GitHub release, build, and push to Octopus Deploy run
-   automatically.
-4. Publish the release to nuget.org manually from Octopus Deploy.
-5. Confirm the artifact at <https://www.nuget.org/packages/Octopus.OpenFeature>.
+1. Merge changes to `main` using a [conventional commit message](https://www.conventionalcommits.org/).
+2. Release Please opens or updates a **release PR** that bumps the version and updates the changelog.
+3. Merge the release PR. The tag, GitHub release, build, and push to Octopus Deploy run automatically.
+4. Promote the release to nuget.org manually from Octopus Deploy.
+5. Confirm the artifact in [NuGet](https://www.nuget.org/packages/Octopus.OpenFeature).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,15 +7,16 @@ Versioning and publishing are automated. Release Please owns the version and cha
 ```mermaid
 flowchart TD
     PR["Merge PR to main<br/>(conventional commit)"]
+    TRIG["Push to main / Pull request / Nightly / Manual"]
 
     PR --> RP["release.yml: release-please"]
-    PR -. "push / PR / nightly" .-> CI["main.yml"]
+    TRIG -. "triggers" .-> CI["main.yml"]
 
     RP -->|"opens / updates"| RPR["Release PR<br/>bumps .csproj (ReleasePleaseVersion) + CHANGELOG"]
     RPR -->|"merged"| TAG["Git tag + GitHub Release"]
 
-    TAG --> ACTR["Build · test · pack<br/>(release version)"]
-    CI --> ACTP["Build · test · pack<br/>(prerelease version: ci / pr.N.branch)"]
+    TAG --> ACTR["Build + test + pack<br/>(release version)"]
+    CI --> ACTP["Build + test + pack<br/>(prerelease version: ci / pr.N.branch)"]
 
     ACTR --> OCT["Octopus Deploy"]
     ACTP --> OCT

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,50 @@
+# Releasing
+
+Versioning and publishing are automated — there is no manual version bump and no hand-cut GitHub
+release. Release Please owns the version and changelog; GitHub Actions builds, tests, and packs the
+package; and Octopus Deploy publishes release versions to nuget.org.
+
+This repo is the reference the Java and TS providers converge on (see DEVEX-318).
+
+## Pipeline
+
+```mermaid
+flowchart TD
+    PR["Merge PR to main<br/>(conventional commit)"]
+
+    PR --> RP["release.yml: release-please"]
+    PR -. "push / PR / nightly" .-> CI["main.yml"]
+
+    RP -->|"opens / updates"| RPR["Release PR<br/>bumps .csproj (ReleasePleaseVersion) + CHANGELOG"]
+    RPR -->|"merged"| TAG["Git tag + GitHub Release"]
+
+    TAG --> ACTR["Build · test · pack<br/>(release version)"]
+    CI --> ACTP["Build · test · pack<br/>(prerelease version: ci / pr.N.branch)"]
+
+    ACTR --> OCT["Octopus Deploy"]
+    ACTP --> OCT
+    OCT -. "release versions<br/>(manual publish)" .-> PUB["Published to nuget.org"]
+    OCT -->|"prereleases"| PRE["Internal only"]
+
+    classDef gh fill:#eef,stroke:#557;
+    classDef oct fill:#efe,stroke:#575;
+    class RP,RPR,TAG,CI,ACTR,ACTP gh;
+    class OCT oct;
+```
+
+- **Prerelease builds** — pushes to `main` (`ci`), PRs (`pr.<number>.<branch>`), and the nightly
+  schedule — are also handed to Octopus Deploy, but their versions stay internal and are not
+  published to nuget.org. `--version-suffix` moves the package version (and
+  `AssemblyInformationalVersion`); `AssemblyVersion`/`FileVersion` stay at the release base.
+- **Release builds** run only after a Release Please PR is merged; the packaged artifact is handed to
+  Octopus Deploy, from which the release version is published to nuget.org by a manual action.
+
+## Cutting a release
+
+1. Land changes on `main` using [conventional commits](https://www.conventionalcommits.org/)
+   (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE` → major).
+2. Release Please opens a **release PR** that bumps the version and updates the changelog.
+3. Merge the release PR. The tag, GitHub release, build, and push to Octopus Deploy run
+   automatically.
+4. Publish the release to nuget.org manually from Octopus Deploy.
+5. Confirm the artifact at <https://www.nuget.org/packages/Octopus.OpenFeature>.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,9 +13,9 @@ flowchart TD
     TRIG -. "triggers" .-> CI["main.yml"]
 
     RP -->|"opens / updates"| RPR["Release PR<br/>bumps .csproj (ReleasePleaseVersion) + CHANGELOG"]
-    RPR -->|"merged"| TAG["Git tag + GitHub Release"]
-
-    TAG --> ACTR["Build + test + pack<br/>(release version)"]
+    RPR -->|"merged"| RP2["release.yml: release-please"]
+    RP2 --> TAG["Git tag + GitHub Release"]
+    RP2 -->|"release_created"| ACTR["Build + test + pack<br/>(release version)"]
     CI --> ACTP["Build + test + pack<br/>(prerelease version: ci / pr.N.branch)"]
 
     ACTR --> OCT["Octopus Deploy"]
@@ -25,7 +25,7 @@ flowchart TD
 
     classDef gh fill:#eef,stroke:#557;
     classDef oct fill:#efe,stroke:#575;
-    class RP,RPR,TAG,CI,ACTR,ACTP gh;
+    class RP,RPR,RP2,TAG,CI,ACTR,ACTP gh;
     class OCT oct;
 ```
 


### PR DESCRIPTION
# Background

We are updating the Java and TypeScript libraries to deploy releases via Octopus Deploy.

The .NET version already releases via Octopus Deploy, but there are a few different moving pieces involved.

This PR adds some documentation to assist future travellers.

