### PR TITLE
fix: Remove "The slug {Slug} did not match any of your Octopus Feature Toggles" log message when evaluating a toggle

### DIFF
--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -425,29 +425,5 @@ public class OctopusFeatureContextTests
     {
         OctopusFeatureContext.GetNormalizedNumber(evaluationKey, targetingKey).Should().Be(expected);
     }
-
-    [Fact]
-    public void WhenSameMissingSlug_IsEvaluatedRepeatedly_OnlyOneWarningIsLogged()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("known-feature", true, "evaluation-key", [], 100)
-        ], []);
-        var fakeLogger = new FakeLogger();
-        var context = new OctopusFeatureContext(featureToggles, new SingleLoggerFactory(fakeLogger));
-
-        for (var i = 0; i < 10; i++)
-        {
-            context.Evaluate("missing-slug", defaultValue: false, context: null);
-        }
-
-        fakeLogger.Collector.GetSnapshot().Should().ContainSingle(r => r.Level == LogLevel.Warning);
-    }
-
-    class SingleLoggerFactory(ILogger logger) : ILoggerFactory
-    {
-        public ILogger CreateLogger(string categoryName) => logger;
-        public void AddProvider(ILoggerProvider provider) { }
-        public void Dispose() { }
-    }
 }
 

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -11,8 +11,6 @@ namespace Octopus.OpenFeature.Provider;
 partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory loggerFactory)
 {
     public byte[] ContentHash => toggles.ContentHash;
-    readonly ILogger logger = loggerFactory.CreateLogger<OctopusFeatureContext>();
-    readonly ConcurrentDictionary<string, byte> warnedSlugs = new(StringComparer.OrdinalIgnoreCase);
 
     public static OctopusFeatureContext Empty(ILoggerFactory loggerFactory)
     {
@@ -30,13 +28,6 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
 
         if (feature == null)
         {
-            if (warnedSlugs.TryAdd(slug, 0))
-            {
-                logger.LogWarning(
-                    "The slug {Slug} did not match any of your Octopus Feature Toggles. Please double check your slug and try again.",
-                    slug);
-            }
-
             return new ResolutionDetails<bool>(slug, defaultValue, ErrorType.FlagNotFound,
                 "The slug provided did not match any of your Octopus Feature Toggles. Please double check your slug and try again.");
         }


### PR DESCRIPTION
# Background

`OctopusFeatureContext` logged a warning message when a toggle was evaluated but no definition could be found from the toggle provider.

This happens when a developer creates a new toggle in code, but doesn't go into Octopus Deploy and define the toggle. The library is attempting to warn about the missing configuration.

# Discussion

If a toggle is being used for staged rollout, or other gradual introduction of a new feature, the logged warning can be useful.
However, another use-case for toggles is as escape hatches. My team does this quite often.

- We'll introduce a code change that we are 99% confident is fine
- We want this code change to be enabled by default, as the new software version rolls out
- We'll create a toggle which restores the old code path, to cover the 1%. Our expectation is that we'll **never** use this toggle, and needing to go into Deploy and define it (and then also clean it up when we clean up the toggle) is a papercut-style tax that it would be nice to avoid.

# Results

Removes the logging.

`OctopusFeatureContext` returns a `ResolutionDetails` with an error message which conveys the same information to the user that the log did, so there is no loss in functionality.