### PR TITLE
chore: Update SDK and test projects to .NET 10

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "10.0.102",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Octopus.OpenFeature.Provider.SpecificationTests/Octopus.OpenFeature.Provider.SpecificationTests.csproj
+++ b/src/Octopus.OpenFeature.Provider.SpecificationTests/Octopus.OpenFeature.Provider.SpecificationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/src/Octopus.OpenFeature.Provider.Tests/Octopus.OpenFeature.Provider.Tests.csproj
+++ b/src/Octopus.OpenFeature.Provider.Tests/Octopus.OpenFeature.Provider.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
Updates test projects and SDK (in global.json) to .NET 10. Library remains on .NET Standard 2.0.

Resolves DEVEX-487