### PR TITLE
ci: add renovate and remove dependabot

### DIFF
--- a/.github/actions/build-test-pack-deploy/action.yml
+++ b/.github/actions/build-test-pack-deploy/action.yml
@@ -70,7 +70,7 @@ runs:
         path: src/${{ steps.package.outputs.name }}
 
     - name: Login to Octopus Deploy 🐙
-      if: github.event.pull_request.head.repo.fork != true && (! contains(github.ref, '/dependabot/'))
+      if: github.event.pull_request.head.repo.fork != true && !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/')
       uses: OctopusDeploy/login@v1
       with:
         server: ${{ inputs.octopus-url }}
@@ -78,14 +78,14 @@ runs:
 
     - name: Push to Octopus 🐙
       uses: OctopusDeploy/push-package-action@v3
-      if: github.event.pull_request.head.repo.fork != true && (! contains(github.ref, '/dependabot/'))
+      if: github.event.pull_request.head.repo.fork != true && !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/')
       with:
         packages: |
           src/${{ steps.package.outputs.name }}
 
     - name: Create Release in Octopus 🐙
       uses: OctopusDeploy/create-release-action@v3
-      if: github.event.pull_request.head.repo.fork != true && (! contains(github.ref, '/dependabot/'))
+      if: github.event.pull_request.head.repo.fork != true && !startsWith(github.head_ref, 'dependabot/') && !startsWith(github.head_ref, 'renovate/')
       with:
         project: "OpenFeature Dotnet Provider"
         packages: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+name: Renovate update dependencies
+on:
+  schedule:
+    # UTC 10:00 PM Sunday - Thursday (AEST 8:00 AM, Monday - Friday)
+    - cron: "0 22 * * 0-4"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    permissions:
+      # Renovate authenticates with RENOVATE_GITHUB_TOKEN, not the default
+      # GITHUB_TOKEN — the latter only needs read access for actions/checkout.
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Renovate
+        uses: renovatebot/github-action@6d859fc95779be83a0335ca704879b47e5d79641 # v46.1.16
+        with:
+          configurationFile: renovate-config.js
+          token: ${{ secrets.RENOVATE_GITHUB_TOKEN }}
+        env:
+          RENOVATE_DRY_RUN: ${{ inputs.dry-run && 'full' || null }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,8 @@
 name: Renovate update dependencies
 on:
   schedule:
-    # UTC 10:00 PM Sunday - Thursday (AEST 8:00 AM, Monday - Friday)
-    - cron: "0 22 * * 0-4"
+    - cron: "0 8 * * 1-5"
+      timezone: "Australia/Brisbane"
   workflow_dispatch:
     inputs:
       dry-run:

--- a/renovate-config.js
+++ b/renovate-config.js
@@ -1,0 +1,53 @@
+module.exports = {
+  platform: 'github',
+  timezone: 'Australia/Brisbane',
+  requireConfig: 'optional',
+  onboarding: false,
+
+  repositories: ['OctopusDeploy/openfeature-provider-dotnet'],
+  reviewers: ['team:team-devex'],
+  branchPrefix: 'renovate/',
+
+  // Limit concurrent PRs for better manageability
+  prConcurrentLimit: 5,
+
+  // Add labels to PRs
+  labels: ['dependencies'],
+
+  // Wait until a release has been published for at least 2 days before updating,
+  // to avoid picking up versions that get yanked or hotfixed shortly after release.
+  minimumReleaseAge: '2 days',
+
+  // Enable vulnerability alerts
+  osvVulnerabilityAlerts: true,
+
+  // Extend with recommended config
+  extends: ['config:recommended'],
+
+  // This repo gates PR titles (amannn/action-semantic-pull-request) and releases
+  // via release-please, both of which require Conventional Commits. Force semantic
+  // commit/PR titles (e.g. "chore(deps): ...", "fix(deps): ...") so Renovate PRs pass.
+  semanticCommits: 'enabled',
+
+  ignoreDeps: [
+    'dotnet-sdk', // We don't want surprise .NET SDK updates in global.json.
+  ],
+
+  enabledManagers: ['nuget', 'github-actions'],
+
+  packageRules: [
+    {
+      // Keep FluentAssertions on v7.x. v8 is no longer free.
+      matchPackageNames: ['FluentAssertions'],
+      allowedVersions: '7.x',
+    },
+    {
+      // GitHub Actions: pin third-party actions to commit SHA for security.
+      matchManagers: ['github-actions'],
+      matchPackageNames: [
+        '!actions/**', // Don't pin official GitHub actions (checkout, setup-dotnet, etc.).
+      ],
+      pinDigests: true,
+    },
+  ],
+};


### PR DESCRIPTION
- Adds Renovate for automated dependency updates (based on the OctoToggle config)
- Adds workflow to run `renovatebot/github-action` on a cron
- 2-day minimum release age
- Validated with `renovate-config-validator` and a dry run locally shows 17 PRs would be raised
- Update `build-test-pack-deploy` action to skip renovate PRs

ℹ️ Workflows only show up when merged into `main` so I haven't done a live run yet

Fixes BMBB-473 and BMBB-497