### PR TITLE
ci: Release OpenFeature bumps as feat

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -53,6 +53,12 @@ module.exports = {
       allowedVersions: '7.x',
     },
     {
+      // OpenFeature SDK updates are worth releasing as a minor version, even if not breaking
+      matchPackageNames: ['OpenFeature'], 
+      matchUpdateTypes: ['minor', 'patch'],
+      semanticCommitType: 'feat',
+    },
+    {
       // GitHub Actions: pin third-party actions to commit SHA for security.
       matchManagers: ['github-actions'],
       matchPackageNames: [


### PR DESCRIPTION
# Background

When we update our OpenFeature SDK dependency, while it is not an actual breaking change, we may be causing friction to our consumers that have a direct reference to the SDK, rather than relying on a transitive dependency.

# Changes

Going forward we will mark these upgrades as `feat` commits so that Release Please will bump the minor version of our provider library.