### PR TITLE
chore(deps): Move recommended config to globalExtends

### DIFF
--- a/renovate-config.js
+++ b/renovate-config.js
@@ -22,7 +22,7 @@ module.exports = {
   osvVulnerabilityAlerts: true,
 
   // Extend with recommended config
-  extends: ['config:recommended'],
+  globalExtends: ['config:recommended'],
 
   // This repo gates PR titles (amannn/action-semantic-pull-request) and releases
   // via release-please, both of which require Conventional Commits. Force semantic


### PR DESCRIPTION
# Background

Renovate config is a [complex beast](https://docs.renovatebot.com/config-overview/).

We want to mark OpenFeature SDK updates as `feat` commits. https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/73

However when defined in global config (i.e. our `renovate-config.js`) `extends` has a higher precedence than `packageRules`, which is the opposite of when defined in a repo level config, so `config:recommended` is overriding the OpenFeature specific configuration.

# Change

Move `config:recommended` from `extends` to `globalExtends` to lower its precedence. https://docs.renovatebot.com/config-overview/#use-of-presets-in-global-config

# Dry run

https://github.com/OctopusDeploy/openfeature-provider-dotnet/actions/runs/29967576044/job/89082310988

`DRY-RUN: Would update PR #77 (repository=OctopusDeploy/openfeature-provider-dotnet, branch=renovate/openfeature-2.x)`: doesn't say _how_ it would update the PR, but local testing indicates it should fix the PR name.