### PR TITLE
feat!: Use new rules-based evaluations

### DIFF
--- a/src/Octopus.OpenFeature.Provider.SpecificationTests/Cases.cs
+++ b/src/Octopus.OpenFeature.Provider.SpecificationTests/Cases.cs
@@ -89,10 +89,11 @@ public record FixtureCase(
 public record FixtureConfiguration(
     string Slug,
     bool DefaultValue,
-    Dictionary<string, string>? Context
+    Dictionary<string, string?>? Context
 );
 
 public record FixtureExpected(
     bool Value,
+    string? Reason = null,
     string? ErrorCode = null
 );

--- a/src/Octopus.OpenFeature.Provider.SpecificationTests/FixtureEvaluationTests.cs
+++ b/src/Octopus.OpenFeature.Provider.SpecificationTests/FixtureEvaluationTests.cs
@@ -40,14 +40,16 @@ public class FixtureEvaluationTests(Server server) : IClassFixture<Server>
         }
     }
 
-    static EvaluationContext BuildContext(Dictionary<string, string>? context)
+    static EvaluationContext BuildContext(Dictionary<string, string?>? context)
     {
         var builder = EvaluationContext.Builder();
 
         context ??= [];
         foreach (var (key, value) in context)
         {
-            builder.Set(key, value);
+            // A null attribute is present in the context but holds no string, which is what a fixture
+            // means by a null value — not an attribute the caller left out.
+            builder.Set(key, value is null ? new Value() : new Value(value));
         }
 
         return builder.Build();

--- a/src/Octopus.OpenFeature.Provider.SpecificationTests/FixtureEvaluationTests.cs
+++ b/src/Octopus.OpenFeature.Provider.SpecificationTests/FixtureEvaluationTests.cs
@@ -31,6 +31,13 @@ public class FixtureEvaluationTests(Server server) : IClassFixture<Server>
         using var scope = new AssertionScope(testCase.Description);
         result.Value.Should().Be(testCase.Expected.Value);
         result.ErrorType.Should().Be(MapErrorCode(testCase.Expected.ErrorCode));
+
+        // Fixtures only state a reason where the specification pins one down, so an absent reason is
+        // not an assertion that the provider returned none.
+        if (testCase.Expected.Reason is { } expectedReason)
+        {
+            result.Reason.Should().Be(expectedReason);
+        }
     }
 
     static EvaluationContext BuildContext(Dictionary<string, string>? context)

--- a/src/Octopus.OpenFeature.Provider.SpecificationTests/Server.cs
+++ b/src/Octopus.OpenFeature.Provider.SpecificationTests/Server.cs
@@ -17,7 +17,7 @@ public class Server : IDisposable
     {
         _server = WireMockServer.Start();
         _server
-            .Given(Request.Create().WithPath("/api/toggles/evaluations/v3/").UsingGet())
+            .Given(Request.Create().WithPath("/api/feature-flags/evaluations/v4/").UsingGet())
             .RespondWith(Response.Create()
                 .WithTransformer()
                 .WithCallback(req =>

--- a/src/Octopus.OpenFeature.Provider.Tests/Octopus.OpenFeature.Provider.Tests.csproj
+++ b/src/Octopus.OpenFeature.Provider.Tests/Octopus.OpenFeature.Provider.Tests.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
         <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="WireMock.Net" Version="2.13.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     </ItemGroup>

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureClientTests.cs
@@ -1,5 +1,9 @@
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging.Abstractions;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Octopus.OpenFeature.Provider.Tests;
 
@@ -59,5 +63,76 @@ public class OctopusFeatureClientTests
 
         var headerValue = httpClient.DefaultRequestHeaders.GetValues("X-Octopus-Client").Single();
         headerValue.Should().Be($"MyProduct openfeature-provider-dotnet/{expectedVersion}");
+    }
+
+    const string CheckPath = "/api/feature-flags/check/v4/";
+    const string EvaluationsPath = "/api/feature-flags/evaluations/v4/";
+
+    static OctopusFeatureClient ClientFor(WireMockServer server)
+    {
+        var configuration = new OctopusFeatureConfiguration("test-id", new ProductMetadata("MyProduct"))
+        {
+            ServerUri = new Uri(server.Url!)
+        };
+
+        return new OctopusFeatureClient(configuration, NullLogger.Instance);
+    }
+
+    static IEnumerable<string> RequestedPaths(WireMockServer server)
+        => server.LogEntries.Select(entry => entry.RequestMessage!.Path);
+
+    [Fact]
+    public async Task HaveFeaturesChanged_RequestsTheV4CheckEndpoint()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath(CheckPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"contentHash":"{{Convert.ToBase64String([0x01, 0x02])}}"}"""));
+
+        var haveFeaturesChanged = await ClientFor(server).HaveFeaturesChanged([0x03, 0x04], CancellationToken.None);
+
+        using var scope = new AssertionScope();
+        RequestedPaths(server).Should().Equal(CheckPath);
+        haveFeaturesChanged.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HaveFeaturesChanged_WhenTheContentHashIsUnchanged_ReportsNoChange()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath(CheckPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{"contentHash":"{{Convert.ToBase64String([0x01, 0x02])}}"}"""));
+
+        var haveFeaturesChanged = await ClientFor(server).HaveFeaturesChanged([0x01, 0x02], CancellationToken.None);
+
+        haveFeaturesChanged.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetServerSideEvaluations_RequestsTheV4EvaluationsEndpoint()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath(EvaluationsPath).UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithHeader("ContentHash", Convert.ToBase64String([0x01, 0x02]))
+                .WithBody("""[{"slug":"test-feature","value":true,"reason":"The flag is enabled for this environment."}]"""));
+
+        var evaluationResponse = await ClientFor(server).GetServerSideEvaluations(CancellationToken.None);
+
+        using var scope = new AssertionScope();
+        RequestedPaths(server).Should().Equal(EvaluationsPath);
+        evaluationResponse.Should().NotBeNull();
+        evaluationResponse!.ContentHash.Should().Equal([0x01, 0x02]);
+        evaluationResponse.Evaluations.Select(evaluation => evaluation.Slug).Should().Equal("test-feature");
     }
 }

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextProviderTests.cs
@@ -3,33 +3,50 @@ using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
+using Octopus.OpenFeature.Provider.V4;
 
 namespace Octopus.OpenFeature.Provider.Tests;
 
 public class OctopusFeatureContextProviderTests
 {
+    const string Slug = "test-feature";
+
     readonly OctopusFeatureConfiguration configuration = new("identifier", new ProductMetadata("test-agent"))
     {
         CacheDuration = TimeSpan.FromSeconds(1)
     };
 
-    class MockOctopusFeatureClient(FeatureToggles? featureToggles) : IOctopusFeatureClient
+    /// <summary>
+    /// A response holding one server-resolved flag. These tests turn on the content hash and the value the
+    /// flag resolves to, so the flag needs no rules of its own.
+    /// </summary>
+    static EvaluationResponse Response(bool value, byte[] contentHash)
+        => new([
+            new ServerSideEvaluation(
+                Slug,
+                value,
+                reason: value ? "The flag is enabled for this environment." : "The flag is disabled for this environment.",
+                evaluationKey: null,
+                rules: null)
+        ], contentHash);
+
+    class MockOctopusFeatureClient(EvaluationResponse? evaluationResponse) : IOctopusFeatureClient
     {
-        FeatureToggles? featureToggles = featureToggles;
+        EvaluationResponse? evaluationResponse = evaluationResponse;
 
         public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
         }
 
-        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+        public Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken)
         {
-            return Task.FromResult(featureToggles);
+            return Task.FromResult(evaluationResponse);
         }
 
-        public void ChangeToggles(FeatureToggles? featureToggles = null)
+        public void ChangeEvaluations(EvaluationResponse? newEvaluationResponse = null)
         {
-            this.featureToggles = featureToggles;
+            this.evaluationResponse = newEvaluationResponse;
         }
     }
 
@@ -50,9 +67,7 @@ public class OctopusFeatureContextProviderTests
     {
         byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
 
-        var client = new MockOctopusFeatureClient(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            contentHash));
+        var client = new MockOctopusFeatureClient(Response(value: true, contentHash));
 
         var provider = new OctopusFeatureContextProvider(configuration, client, NullLogger.Instance);
         await provider.Initialize();
@@ -61,7 +76,7 @@ public class OctopusFeatureContextProviderTests
         using var scope = new AssertionScope();
         context.Should().NotBeNull();
         context.ContentHash.Should().BeEquivalentTo(contentHash);
-        context.Evaluate("test-feature", false, context: null).Value.Should().BeTrue();
+        context.Evaluate(Slug, context: null).Value.Should().BeTrue();
     }
 
     [Fact]
@@ -69,9 +84,7 @@ public class OctopusFeatureContextProviderTests
     {
         byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
 
-        var client = new MockOctopusFeatureClient(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            contentHash));
+        var client = new MockOctopusFeatureClient(Response(value: true, contentHash));
 
         // Initialize the provider
         var provider = new OctopusFeatureContextProvider(configuration, client, NullLogger.Instance);
@@ -81,20 +94,18 @@ public class OctopusFeatureContextProviderTests
         using var scope = new AssertionScope();
         var context = provider.GetEvaluationContext();
         context.ContentHash.Should().BeEquivalentTo(contentHash);
-        context.Evaluate("test-feature", false, context: null).Value.Should().BeTrue();
+        context.Evaluate(Slug, context: null).Value.Should().BeTrue();
 
-        // Simulate a change in the available feature toggles
-        client.ChangeToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)],
-            [0x01, 0x02, 0x03, 0x05]));
+        // Simulate a change in the available feature flags
+        client.ChangeEvaluations(Response(value: false, [0x01, 0x02, 0x03, 0x05]));
 
         // Wait for the cache to expire
         await Task.Delay(TimeSpan.FromSeconds(5));
 
-        // Validate the updated toggles are available
+        // Validate the updated evaluations are available
         context = provider.GetEvaluationContext();
         context.ContentHash.Should().BeEquivalentTo(new byte[] { 0x01, 0x02, 0x03, 0x05 });
-        context.Evaluate("test-feature", false, context: null).Value.Should().BeFalse();
+        context.Evaluate(Slug, context: null).Value.Should().BeFalse();
     }
 
     [Fact]
@@ -104,16 +115,13 @@ public class OctopusFeatureContextProviderTests
 
         byte[] contentHash = [0x01, 0x02, 0x03, 0x04];
 
-        var client = new MockOctopusFeatureClient(new FeatureToggles(
-            [new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)],
-            contentHash
-        ));
+        var client = new MockOctopusFeatureClient(Response(value: true, contentHash));
 
         var provider = new OctopusFeatureContextProvider(configuration, client, logger);
         await provider.Initialize();
 
         // Simulate a failed fetch
-        client.ChangeToggles(null);
+        client.ChangeEvaluations(null);
         // Wait for the cache to expire and refresh loop to run
         await Task.Delay(TimeSpan.FromSeconds(5));
 
@@ -148,8 +156,8 @@ public class OctopusFeatureContextProviderTests
             // Check that the context is empty
             provider.GetEvaluationContext().ContentHash.Length.Should().Be(0);
 
-            // Update client to return valid toggles and wait for refresh
-            client.ChangeToggles(new FeatureToggles([new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)], contentHash));
+            // Update client to return valid evaluations and wait for refresh
+            client.ChangeEvaluations(Response(value: false, contentHash));
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert that the context is now correctly populated
@@ -169,23 +177,23 @@ public class OctopusFeatureContextProviderTests
         byte[] initialHash = [0x01, 0x02, 0x03, 0x04];
         byte[] updatedHash = [0x01, 0x02, 0x03, 0x05];
 
-        // Initialize with a client that returns valid toggles
-        var client = new MockOctopusFeatureClient(new FeatureToggles([new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)], initialHash));
+        // Initialize with a client that returns valid evaluations
+        var client = new MockOctopusFeatureClient(Response(value: true, initialHash));
         var provider = new OctopusFeatureContextProvider(configuration, client, logger);
         await provider.Initialize();
 
         try
         {
             // Switch to a null client and wait for refresh to fail
-            client.ChangeToggles(null);
+            client.ChangeEvaluations(null);
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert that failed refresh is logged and old context is retained
             logger.LatestRecord.Message.Should().StartWith("Failed to retrieve updated feature manifest");
             provider.GetEvaluationContext().ContentHash.Should().BeEquivalentTo(initialHash);
 
-            // Update client to return valid toggles again and wait for refresh
-            client.ChangeToggles(new FeatureToggles([new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)], updatedHash));
+            // Update client to return valid evaluations again and wait for refresh
+            client.ChangeEvaluations(Response(value: false, updatedHash));
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert that the context is now correctly populated
@@ -198,7 +206,7 @@ public class OctopusFeatureContextProviderTests
         }
     }
 
-    class ThrowsOnRefreshClient(FeatureToggles initial) : IOctopusFeatureClient
+    class ThrowsOnRefreshClient(EvaluationResponse initial) : IOctopusFeatureClient
     {
         public readonly string ErrorMessage = "Oops! Simulated refresh error";
 
@@ -207,9 +215,9 @@ public class OctopusFeatureContextProviderTests
             throw new Exception(ErrorMessage);
         }
 
-        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+        public Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken)
         {
-            return Task.FromResult<FeatureToggles?>(initial);
+            return Task.FromResult<EvaluationResponse?>(initial);
         }
     }
 
@@ -220,9 +228,7 @@ public class OctopusFeatureContextProviderTests
         var logger = new FakeLogger();
 
         // Initialize with a client that will throw on refresh
-        var client = new ThrowsOnRefreshClient(
-            new FeatureToggles([new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)], contentHash)
-        );
+        var client = new ThrowsOnRefreshClient(Response(value: true, contentHash));
         var provider = new OctopusFeatureContextProvider(configuration, client, logger);
         await provider.Initialize();
 
@@ -250,7 +256,7 @@ public class OctopusFeatureContextProviderTests
             return Task.FromResult(true);
         }
 
-        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+        public Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken)
         {
             throw new Exception("Oops!");
         }

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -3,302 +3,68 @@ using FluentAssertions.Execution;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
+using Octopus.OpenFeature.Provider.V4;
 using OpenFeature.Constant;
-using OpenFeature.Model;
+using OpenFeature.Error;
 
 namespace Octopus.OpenFeature.Provider.Tests;
 
 public class OctopusFeatureContextTests
 {
+    static ServerSideEvaluation Flag(string slug, bool value)
+        => new(
+            slug,
+            value,
+            reason: value ? "The flag is enabled for this environment." : "The flag is disabled for this environment.",
+            evaluationKey: null,
+            rules: null);
+
+    static OctopusFeatureContext ContextWith(params ServerSideEvaluation[] evaluations)
+        => ContextWith(NullLoggerFactory.Instance, evaluations);
+
+    static OctopusFeatureContext ContextWith(ILoggerFactory loggerFactory, params ServerSideEvaluation[] evaluations)
+        => new(new EvaluationResponse(evaluations, []), loggerFactory);
+
     [Fact]
-    public void EvaluatesToTrue_IfFeatureIsContainedWithinTheSet_AndFeatureIsEnabled()
+    public void Evaluate_WhenTheFlagIsInTheResponse_ReturnsTheFlagsEvaluation()
     {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)
-        ], []);
+        var featureContext = ContextWith(Flag("test-feature", true));
 
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
+        var result = featureContext.Evaluate("test-feature", context: null);
 
-        var result = context.Evaluate("test-feature", false, context: null);
+        using var scope = new AssertionScope();
+        result.Value.Should().BeTrue();
+        result.Reason.Should().Be("The flag is enabled for this environment.");
+    }
+
+    [Fact]
+    public void Evaluate_WhenTheSlugDiffersOnlyInCase_ReturnsTheFlagValue()
+    {
+        var featureContext = ContextWith(Flag("test-feature", true));
+
+        var result = featureContext.Evaluate("Test-Feature", context: null);
 
         result.Value.Should().BeTrue();
     }
 
     [Fact]
-    public void WhenEvaluatedWithCasingDifferences_EvaluationIsInsensitiveToCase()
+    public void Evaluate_WhenTheFlagKeyIsNotASlug_ThrowsFlagNotFound()
     {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)
-        ], []);
+        var featureContext = ContextWith(Flag("this-is-clearly-not-a-slug", true));
 
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
+        var evaluate = () => featureContext.Evaluate("This is clearly not a slug!", context: null);
 
-        var result = context.Evaluate("Test-Feature", false, context: null);
-
-        result.Value.Should().BeTrue();
+        evaluate.Should().Throw<FlagNotFoundException>().Which.ErrorType.Should().Be(ErrorType.FlagNotFound);
     }
 
     [Fact]
-    public void EvaluatesToFalse_IfFeatureIsContainedWithinTheSet_AndFeatureIsNotEnabled()
+    public void Evaluate_WhenTheFlagIsNotInTheResponse_ThrowsFlagNotFound()
     {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", false, "evaluation-key", [], 100)
-        ], []);
+        var featureContext = ContextWith(Flag("testfeature", false));
 
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
+        var evaluate = () => featureContext.Evaluate("anotherfeature", context: null);
 
-        var result = context.Evaluate("test-feature", false, context: null);
-
-        result.Value.Should().BeFalse();
-    }
-
-    [Fact]
-    public void GivenAFlagKeyThatIsNotASlug_ReturnsFlagNotFound_AndEvaluatesToDefaultValue()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("this-is-clearly-not-a-slug", true, "evaluation-key", [], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        var result = context.Evaluate("This is clearly not a slug!", defaultValue: true, context: null);
-
-        result.ErrorType.Should().Be(ErrorType.FlagNotFound);
-        result.Value.Should().BeTrue();
-    }
-
-    [Fact]
-    public void EvaluatesToDefaultValue_IfFeatureIsNotContainedWithinSet()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("testfeature", false, "evaluation-key", [], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        var result = context.Evaluate("anotherfeature", defaultValue: true, context: null);
-
-        result.ErrorType.Should().Be(ErrorType.FlagNotFound);
-        result.Value.Should().BeTrue();
-    }
-
-    EvaluationContext BuildContext(IEnumerable<(string key, string value)> values, string? targetingKey = null)
-    {
-        var builder = EvaluationContext.Builder();
-        foreach (var (key, value) in values)
-        {
-            builder.Set(key, value);
-        }
-        if (targetingKey != null)
-        {
-            builder.SetTargetingKey(targetingKey);
-        }
-        return builder.Build();
-    }
-
-    [Fact]
-    public void
-        WhenAFeatureIsToggledOnForASpecificSegment_EvaluatesToTrueWhenSegmentIsSpecified()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("testfeature", true, "evaluation-key", [new("license", "trial")], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        using var scope = new AssertionScope();
-        context.Evaluate("testfeature", false, context: BuildContext([("license", "trial")])).Value.Should().BeTrue();
-        context.Evaluate("testfeature", false, context: BuildContext([("other", "segment")])).Value.Should().BeFalse();
-        context.Evaluate("testfeature", false, context: null).Value.Should().BeFalse();
-    }
-
-    [Fact]
-    public void
-        WhenFeatureIsNotToggledOnForSpecificSegments_EvaluatesToTrueRegardlessOfSegmentSpecified()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("testfeature", true, "evaluation-key", [], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        using var scope = new AssertionScope();
-        context.Evaluate("testfeature", false, context: BuildContext([("license", "trial")])).Value.Should().BeTrue();
-        context.Evaluate("testfeature", false, context: null).Value.Should().BeTrue();
-    }
-
-    [Fact]
-    public void WhenAFeatureIsToggledOnForMultipleSegments_EvaluatesCorrectly()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation(
-                "testfeature", true, "evaluation-key", [
-                    new("license", "trial"),
-                    new("region", "au"),
-                    new("region", "us"),
-                ],
-                100
-            )
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        using var scope = new AssertionScope();
-
-        // A matching context value is present for each toggled segment
-        context.Evaluate("testfeature", false, context: BuildContext([("license", "trial"), ("region", "us")])).Value
-            .Should().BeTrue("when there is a matching context value for each toggled segment, the toggle should be enabled");
-
-        // A context value is present for each toggled segment, but it is not toggled on for one of the supplied values
-        context.Evaluate("testfeature", false, context: BuildContext([("license", "trial"), ("region", "eu")])).Value
-            .Should().BeFalse("when there is a matching context value for each toggled segment, but the context value does not match the toggled segment, the toggle should be disabled");
-
-        // A matching context value is present for each toggled segment, and an additional segment is present in the provided context values
-        context.Evaluate("testfeature", false,
-                context: BuildContext([("license", "trial"), ("region", "us"), ("language", "english")])).Value.Should()
-            .BeTrue("when extra context values are present, the toggle should still be enabled");
-
-        // A context value is present for only one of the two toggled segments
-        context.Evaluate("testfeature", false, context: BuildContext([("license", "trial")])).Value.Should()
-            .BeFalse("when the context does not contain a value for all toggled segments, the toggle should be disabled");
-
-        // No context values are present for the two toggled segment
-        // Note that the default value is only returned if evaluation fails for an unexpected reason.
-        // In this case, the default value is not returned, as we have a successful, but false, flag evaluation.
-        context.Evaluate("testfeature", true, context: BuildContext([("other", "segment")])).Value.Should()
-            .BeFalse("when the context does not contain a value for all toggled segments, the toggle should be disabled");
-
-        // None specified
-        context.Evaluate("testfeature", true, context: null).Value.Should().BeFalse("when no context values are present, and the feature is toggled on for a segment, the toggle should be disabled");
-    }
-
-    [Fact]
-    public void
-        WhenAFeatureIsToggledOnForASpecificSegment_ToleratesNullValuesInContext()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("testfeature", true, "evaluation-key", [new("license", "trial")], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        using var scope = new AssertionScope();
-        context.Evaluate("testfeature", false, context: BuildContext([("license", null)!])).Value.Should().BeFalse();
-        context.Evaluate("testfeature", false, context: BuildContext([("other", "segment")])).Value.Should().BeFalse();
-        context.Evaluate("testfeature", false, context: null).Value.Should().BeFalse();
-    }
-
-    [Fact]
-    public void WhenTargetingKeyFallsWithinRolloutPercentage_AndFeatureIsNotToggledForSegments_ResolvesToTrue()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 13)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        // Key resolves to 13 => segment is within rollout percentage
-        var evaluationContext = BuildContext([], targetingKey: "targeting-key");
-        var result = context.Evaluate("test-feature", false, evaluationContext);
-
-        result.Value.Should().BeTrue("segment is within rollout percentage");
-    }
-
-    [Fact]
-    public void WhenTargetingKeyFallsOutsideRolloutPercentage_AndFeatureIsNotToggledForSegments_ResolvesToFalse()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 12)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        // Key resolves to 13 > 12 => segment is outside of rollout percentage
-        var evaluationContext = BuildContext([], targetingKey: "targeting-key");
-        var result = context.Evaluate("test-feature", false, evaluationContext);
-
-        result.Value.Should().BeFalse("segment is outside of rollout percentage");
-    }
-
-    [Fact]
-    public void WhenTargetingKeyFallsWithinRolloutPercentage_AndSegmentMatchesRequiredSegments_EvaluatesToTrue()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [new("license", "trial")], 13)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        // Key resolves to 13 => segment is within rollout percentage
-        var evaluationContext = BuildContext([("license", "trial")], targetingKey: "targeting-key");
-
-        using var scope = new AssertionScope();
-        context.Evaluate("test-feature", false, evaluationContext).Value.Should()
-            .BeTrue("segment matches required segment and falls within rollout percentage");
-    }
-
-    [Fact]
-    public void WhenTargetingKeyFallsWithinRolloutPercentage_AndSegmentValueDoesNotMatchRequiredSegment_EvaluatesToFalse()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [new("license", "enterprise")], 99)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        // Key resolves to 13 => segment is within rollout percentage
-        var evaluationContext = BuildContext([("license", "trial")], targetingKey: "targeting-key");
-
-        using var scope = new AssertionScope();
-        context.Evaluate("test-feature", false, evaluationContext).Value.Should()
-            .BeFalse("segment value does not match required segment");
-    }
-
-    [Fact]
-    public void WhenTargetingKeyFallsOutsideRolloutPercentage_AndSegmentValueDoesNotMatchRequiredSegment_EvaluatesToFalse()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [new("license", "enterprise")], 12)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        // Key resolves to 13 > 12 => segment is outside of rollout percentage
-        var evaluationContext = BuildContext([("license", "trial")], targetingKey: "targeting-key");
-
-        using var scope = new AssertionScope();
-        context.Evaluate("test-feature", false, evaluationContext).Value.Should()
-            .BeFalse("segment is outside of rollout percentage");
-    }
-
-    [Fact]
-    public void WhenNoTargetingKey_RolloutIsLessThanOneHundredPercent_ResolvesToFalse()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 99)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        var evaluationContext = BuildContext([], targetingKey: null);
-        var result = context.Evaluate("test-feature", false, evaluationContext);
-
-        result.Value.Should().BeFalse("no targeting key and rollout is less than 100%");
-    }
-
-    [Fact]
-    public void WhenNoTargetingKey_RolloutIsEqualToOneHundredPercent_ResolvesToTrue()
-    {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("test-feature", true, "evaluation-key", [], 100)
-        ], []);
-
-        var context = new OctopusFeatureContext(featureToggles, NullLoggerFactory.Instance);
-
-        var evaluationContext = BuildContext([], targetingKey: null);
-        var result = context.Evaluate("test-feature", false, evaluationContext);
-
-        result.Value.Should().BeTrue("no targeting key and rollout is 100%");
+        evaluate.Should().Throw<FlagNotFoundException>().Which.ErrorType.Should().Be(ErrorType.FlagNotFound);
     }
 
     // These cases verify that GetNormalizedNumber produces the same bucketing values as the equivalent
@@ -421,23 +187,21 @@ public class OctopusFeatureContextTests
     [InlineData("experiment-a", "пользователь", 81)]
     [InlineData("test-feature", "사용자", 62)]
     [InlineData("dark-launch", "テナント-001", 8)]
-    public void GetNormalizedNumber_MatchesExpectedValue(string evaluationKey, string targetingKey, int expected)
+    public void GetNormalizedNumber_WhenGivenAnEvaluationAndTargetingKey_ReturnsTheSharedBucket(string evaluationKey, string targetingKey, int expected)
     {
         OctopusFeatureContext.GetNormalizedNumber(evaluationKey, targetingKey).Should().Be(expected);
     }
 
     [Fact]
-    public void WhenSameMissingSlug_IsEvaluatedRepeatedly_OnlyOneWarningIsLogged()
+    public void Evaluate_WhenTheSameMissingSlugIsEvaluatedRepeatedly_LogsOneWarning()
     {
-        var featureToggles = new FeatureToggles([
-            new FeatureToggleEvaluation("known-feature", true, "evaluation-key", [], 100)
-        ], []);
         var fakeLogger = new FakeLogger();
-        var context = new OctopusFeatureContext(featureToggles, new SingleLoggerFactory(fakeLogger));
+        var featureContext = ContextWith(new SingleLoggerFactory(fakeLogger), Flag("known-feature", true));
 
         for (var i = 0; i < 10; i++)
         {
-            context.Evaluate("missing-slug", defaultValue: false, context: null);
+            var evaluate = () => featureContext.Evaluate("missing-slug", context: null);
+            evaluate.Should().Throw<FlagNotFoundException>();
         }
 
         fakeLogger.Collector.GetSnapshot().Should().ContainSingle(r => r.Level == LogLevel.Warning);
@@ -450,4 +214,3 @@ public class OctopusFeatureContextTests
         public void Dispose() { }
     }
 }
-

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureContextTests.cs
@@ -38,13 +38,15 @@ public class OctopusFeatureContextTests
     }
 
     [Fact]
-    public void Evaluate_WhenTheSlugDiffersOnlyInCase_ReturnsTheFlagValue()
+    public void Evaluate_WhenTheSlugDiffersOnlyInCase_ReturnsTheFlagValueAndTheFlagsOwnSlug()
     {
         var featureContext = ContextWith(Flag("test-feature", true));
 
         var result = featureContext.Evaluate("Test-Feature", context: null);
 
+        using var scope = new AssertionScope();
         result.Value.Should().BeTrue();
+        result.FlagKey.Should().Be("test-feature");
     }
 
     [Fact]

--- a/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureProviderTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/OctopusFeatureProviderTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Octopus.OpenFeature.Provider.V4;
 using OpenFeature;
 using OpenFeature.Constant;
 using OpenFeature.Model;
@@ -9,15 +10,20 @@ public class OctopusFeatureProviderTests
 {
     readonly OctopusFeatureConfiguration configuration = new("identifier", new ProductMetadata("test-agent"));
 
-    class FakeOctopusFeatureClient(FeatureToggles? featureToggles) : IOctopusFeatureClient
+    class FakeOctopusFeatureClient(EvaluationResponse? evaluationResponse) : IOctopusFeatureClient
     {
         public Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken) => Task.FromResult(false);
-        public Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken) => Task.FromResult(featureToggles);
+        public Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken) => Task.FromResult(evaluationResponse);
     }
 
-    async Task<FeatureClient> CreateClientWithToggles(FeatureToggles toggles)
+    static ServerSideEvaluation Flag(string slug)
+        => new(slug, value: true, reason: "The flag is enabled for this environment.", evaluationKey: null, rules: null);
+
+    static EvaluationResponse Response(params ServerSideEvaluation[] evaluations) => new(evaluations, []);
+
+    async Task<FeatureClient> CreateClientWith(EvaluationResponse evaluationResponse)
     {
-        var provider = new OctopusFeatureProvider(configuration, new FakeOctopusFeatureClient(toggles));
+        var provider = new OctopusFeatureProvider(configuration, new FakeOctopusFeatureClient(evaluationResponse));
         await Api.Instance.SetProviderAsync(provider);
         return Api.Instance.GetClient();
     }
@@ -25,8 +31,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetStringDetailsAsync_WhenFlagExists_ReturnTypeMismatchError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("my-flag", true, "key", [], 100)], []));
+        var client = await CreateClientWith(Response(Flag("my-flag")));
 
         var result = await client.GetStringDetailsAsync("my-flag", "default");
         await Api.Instance.ShutdownAsync();
@@ -37,7 +42,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetStringDetailsAsync_WhenFlagDoesNotExist_ReturnsFlagNotFoundError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles([], []));
+        var client = await CreateClientWith(Response());
 
         var result = await client.GetStringDetailsAsync("unknown-flag", "default");
         await Api.Instance.ShutdownAsync();
@@ -48,8 +53,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetIntegerDetailsAsync_WhenFlagExists_ReturnTypeMismatchError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("my-flag", true, "key", [], 100)], []));
+        var client = await CreateClientWith(Response(Flag("my-flag")));
 
         var result = await client.GetIntegerDetailsAsync("my-flag", 0);
         await Api.Instance.ShutdownAsync();
@@ -60,7 +64,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetIntegerDetailsAsync_WhenFlagDoesNotExist_ReturnsFlagNotFoundError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles([], []));
+        var client = await CreateClientWith(Response());
 
         var result = await client.GetIntegerDetailsAsync("unknown-flag", 0);
         await Api.Instance.ShutdownAsync();
@@ -71,8 +75,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetDoubleDetailsAsync_WhenFlagExists_ReturnTypeMismatchError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("my-flag", true, "key", [], 100)], []));
+        var client = await CreateClientWith(Response(Flag("my-flag")));
 
         var result = await client.GetDoubleDetailsAsync("my-flag", 0.0);
         await Api.Instance.ShutdownAsync();
@@ -83,7 +86,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetDoubleDetailsAsync_WhenFlagDoesNotExist_ReturnsFlagNotFoundError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles([], []));
+        var client = await CreateClientWith(Response());
 
         var result = await client.GetDoubleDetailsAsync("unknown-flag", 0.0);
         await Api.Instance.ShutdownAsync();
@@ -94,8 +97,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetObjectDetailsAsync_WhenFlagExists_ReturnTypeMismatchError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles(
-            [new FeatureToggleEvaluation("my-flag", true, "key", [], 100)], []));
+        var client = await CreateClientWith(Response(Flag("my-flag")));
 
         var result = await client.GetObjectDetailsAsync("my-flag", new Value());
         await Api.Instance.ShutdownAsync();
@@ -106,7 +108,7 @@ public class OctopusFeatureProviderTests
     [Fact]
     public async Task GetObjectDetailsAsync_WhenFlagDoesNotExist_ReturnsFlagNotFoundError()
     {
-        var client = await CreateClientWithToggles(new FeatureToggles([], []));
+        var client = await CreateClientWith(Response());
 
         var result = await client.GetObjectDetailsAsync("unknown-flag", new Value());
         await Api.Instance.ShutdownAsync();

--- a/src/Octopus.OpenFeature.Provider.Tests/V4/ServerSideEvaluationTests.cs
+++ b/src/Octopus.OpenFeature.Provider.Tests/V4/ServerSideEvaluationTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions.Execution;
 using Octopus.OpenFeature.Provider.V4;
 using Octopus.OpenFeature.Provider.V4.Conditions;
 using OpenFeature.Constant;
+using OpenFeature.Error;
 
 namespace Octopus.OpenFeature.Provider.Tests.V4;
 
@@ -37,14 +38,14 @@ public class ServerSideEvaluationTests
     }
 
     [Fact]
-    public void ServerResolvedFlagWithNoReason_StillResolves()
+    public void ServerResolvedFlagWithNoReason_ThrowsAParseError()
     {
-        var result = ServerResolved(true, reason: null).Evaluate(Contexts.OpenFeature());
+        var evaluate = () => ServerResolved(true, reason: null).Evaluate(Contexts.OpenFeature());
 
         using var scope = new AssertionScope();
-        result.Value.Should().BeTrue();
-        result.Reason.Should().BeNull();
-        result.ErrorType.Should().Be(ErrorType.None);
+        var exception = evaluate.Should().Throw<ParseErrorException>().Which;
+        exception.ErrorType.Should().Be(ErrorType.ParseError);
+        exception.Message.Should().Be("The flag has a value but has no reason.");
     }
 
     [Fact]

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -9,7 +9,7 @@ namespace Octopus.OpenFeature.Provider;
 internal class FeatureToggles(FeatureToggleEvaluation[] evaluations, byte[] contentHash)
 {
     // TODO: Remove in BMBB-702
-    
+
     public FeatureToggleEvaluation[] Evaluations { get; } = evaluations;
 
     public byte[] ContentHash { get; } = contentHash;
@@ -30,7 +30,7 @@ internal class FeatureToggleEvaluation(
     int? clientRolloutPercentage)
 {
     // TODO: Remove in BMBB-702
-    
+
     public string Slug { get; } = slug;
     public bool IsEnabled { get; } = isEnabled;
     public string? EvaluationKey { get; } = evaluationKey;

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -2,12 +2,22 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Octopus.OpenFeature.Provider.V4;
 
 namespace Octopus.OpenFeature.Provider;
 
 public class FeatureToggles(FeatureToggleEvaluation[] evaluations, byte[] contentHash)
 {
+    // TODO: Remove in BMBB-702
+    
     public FeatureToggleEvaluation[] Evaluations { get; } = evaluations;
+
+    public byte[] ContentHash { get; } = contentHash;
+}
+
+internal class EvaluationResponse(ServerSideEvaluation[] evaluations, byte[] contentHash)
+{
+    public ServerSideEvaluation[] Evaluations { get; } = evaluations;
 
     public byte[] ContentHash { get; } = contentHash;
 }
@@ -19,6 +29,8 @@ public class FeatureToggleEvaluation(
     KeyValuePair<string, string>[]? segments,
     int? clientRolloutPercentage)
 {
+    // TODO: Remove in BMBB-702
+    
     public string Slug { get; } = slug;
     public bool IsEnabled { get; } = isEnabled;
     public string? EvaluationKey { get; } = evaluationKey;
@@ -29,13 +41,13 @@ public class FeatureToggleEvaluation(
 interface IOctopusFeatureClient
 {
     Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken);
-    Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken);
+    Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken);
 }
 
 /// <summary>
-/// Responsible for retrieving feature toggles from OctoToggle and determining if they have changed.
+/// Responsible for determining if feature flags have been modified and for retrieving their server-side evaluations.
 /// </summary>
-class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger logger) : IOctopusFeatureClient
+internal class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger logger) : IOctopusFeatureClient
 {
     public async Task<bool> HaveFeaturesChanged(byte[] contentHash, CancellationToken cancellationToken)
     {
@@ -64,7 +76,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         if (hash is null)
         {
-            throw new InvalidOperationException($"Failed to retrieve feature toggles for client identifier. Check did not return a valid content hash.");
+            throw new InvalidOperationException($"Failed to retrieve feature flags for client identifier. Check did not return a valid content hash.");
         }
 
         var haveFeaturesChanged = !hash.ContentHash.SequenceEqual(contentHash);
@@ -94,13 +106,13 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
     }
 
     /// <summary>
-    /// Retrieves the evaluated feature set from OctoToggle for a given installation and project.
+    /// Retrieves the server-side evaluated feature flags for a given installation and project.
     /// This method will return null if:
-    /// - Toggles are not found for the installation and id
+    /// - Flags are not found for the installation and id
     /// - We don't receive a ContentHash header
-    /// - We cannot deserialize the content response into a OctoToggleFeatureManifest
+    /// - We cannot deserialize the content response
     /// </summary>
-    public async Task<FeatureToggles?> GetFeatureToggleEvaluationManifest(CancellationToken cancellationToken)
+    public async Task<EvaluationResponse?> GetServerSideEvaluations(CancellationToken cancellationToken)
     {
         var client = new HttpClient
         {
@@ -119,20 +131,20 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            logger.LogWarning("Failed to retrieve feature toggles for client identifier {ClientIdentifier} from {OctoToggleUrl}", configuration.ClientIdentifier, configuration.ServerUri);
+            logger.LogWarning("Failed to retrieve feature flags for client identifier {ClientIdentifier} from {OctoToggleUrl}", configuration.ClientIdentifier, configuration.ServerUri);
             return null;
         }
 
         if (!response.Headers.TryGetValues("ContentHash", out IEnumerable<string> values))
         {
-            logger.LogWarning("Feature toggle response from {OctoToggleUrl} did not contain expected ContentHash header", configuration.ServerUri);
+            logger.LogWarning("Feature flag response from {OctoToggleUrl} did not contain expected ContentHash header", configuration.ServerUri);
             return null;
         }
 
         var headerValues = values.ToArray();
         if (!headerValues.Any())
         {
-            logger.LogWarning("Feature toggle response from {OctoToggleUrl} returned an empty ContentHash header", configuration.ServerUri);
+            logger.LogWarning("Feature flag response from {OctoToggleUrl} returned an empty ContentHash header", configuration.ServerUri);
             return null;
         }
 
@@ -140,16 +152,16 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         var result = await response.Content.ReadAsStringAsync();
 
-        var evaluations = JsonSerializer.Deserialize<FeatureToggleEvaluation[]>(result, JsonSerializerOptions.Web);
+        var evaluations = JsonSerializer.Deserialize<ServerSideEvaluation[]>(result, JsonSerializerOptions.Web);
 
         if (evaluations is null)
         {
-            logger.LogWarning("Feature toggle response content from {OctoToggleUrl} was empty", configuration.ServerUri);
+            logger.LogWarning("Feature flag response content from {OctoToggleUrl} was empty", configuration.ServerUri);
             return null;
         }
 
-        var toggles = new FeatureToggles(evaluations, Convert.FromBase64String(rawContentHash));
+        var evaluationResponse = new EvaluationResponse(evaluations, Convert.FromBase64String(rawContentHash));
 
-        return toggles;
+        return evaluationResponse;
     }
 }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -76,7 +76,7 @@ internal class OctopusFeatureClient(OctopusFeatureConfiguration configuration, I
 
         if (hash is null)
         {
-            throw new InvalidOperationException($"Failed to retrieve feature flags for client identifier. Check did not return a valid content hash.");
+            throw new InvalidOperationException("Failed to retrieve feature flags for client identifier. Check did not return a valid content hash.");
         }
 
         var haveFeaturesChanged = !hash.ContentHash.SequenceEqual(contentHash);

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -6,7 +6,7 @@ using Octopus.OpenFeature.Provider.V4;
 
 namespace Octopus.OpenFeature.Provider;
 
-public class FeatureToggles(FeatureToggleEvaluation[] evaluations, byte[] contentHash)
+internal class FeatureToggles(FeatureToggleEvaluation[] evaluations, byte[] contentHash)
 {
     // TODO: Remove in BMBB-702
     
@@ -22,7 +22,7 @@ internal class EvaluationResponse(ServerSideEvaluation[] evaluations, byte[] con
     public byte[] ContentHash { get; } = contentHash;
 }
 
-public class FeatureToggleEvaluation(
+internal class FeatureToggleEvaluation(
     string slug,
     bool isEnabled,
     string? evaluationKey,

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureClient.cs
@@ -53,7 +53,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
         FeatureCheck? hash = null;
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var result = await client.GetAsync("api/featuretoggles/check/v3/", cancellationToken);
+        var result = await client.GetAsync("api/feature-flags/check/v4/", cancellationToken);
 
         if (result.IsSuccessStatusCode)
         {
@@ -115,7 +115,7 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {configuration.ClientIdentifier}");
 
-        var response = await client.GetAsync("api/toggles/evaluations/v3/", cancellationToken);
+        var response = await client.GetAsync("api/feature-flags/evaluations/v4/", cancellationToken);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -138,9 +138,6 @@ class OctopusFeatureClient(OctopusFeatureConfiguration configuration, ILogger lo
 
         var rawContentHash = headerValues.First();
 
-        // WARNING: v2 and v3 endpoints have identical response contracts.
-        // If for any reason the v3 endpoint response contract starts to diverge from the v2 contract,
-        // This code will need to update accordingly
         var result = await response.Content.ReadAsStringAsync();
 
         var evaluations = JsonSerializer.Deserialize<FeatureToggleEvaluation[]>(result, JsonSerializerOptions.Web);

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -41,7 +41,7 @@ internal class OctopusFeatureContext(EvaluationResponse evaluationResponse, ILog
 
             throw new FlagNotFoundException("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.");
         }
-        
+
         return serverSideEvaluation.Evaluate(context);
     }
 
@@ -65,7 +65,7 @@ internal class OctopusFeatureContext(EvaluationResponse evaluationResponse, ILog
     bool Evaluate(FeatureToggleEvaluation evaluation, EvaluationContext? context = null)
     {
         // Remove in BMBB-702
-        
+
         if (!evaluation.IsEnabled)
         {
             return false;
@@ -100,7 +100,7 @@ internal class OctopusFeatureContext(EvaluationResponse evaluationResponse, ILog
     internal static int GetNormalizedNumber(string evaluationKey, string targetingKey)
     {
         // Move to own class in BMBB-702. Perhaps copy+paste of PercentageRollout.cs in OctoToggle?
-        
+
         var bytes = Encoding.UTF8.GetBytes(string.Concat(evaluationKey, ":", targetingKey));
 
         using var algorithm = MurmurHash.Create32();

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -21,14 +21,14 @@ internal class OctopusFeatureContext(EvaluationResponse evaluationResponse, ILog
         return new OctopusFeatureContext(new EvaluationResponse([], []), loggerFactory);
     }
 
-    internal ServerSideEvaluation? FindFeatureToggleBySlug(string slug)
+    internal ServerSideEvaluation? FindEvaluationBySlug(string slug)
     {
         return evaluationResponse.Evaluations.FirstOrDefault(x => x.Slug.Equals(slug, StringComparison.OrdinalIgnoreCase));
     }
 
     public ResolutionDetails<bool> Evaluate(string slug, EvaluationContext? context)
     {
-        var serverSideEvaluation = FindFeatureToggleBySlug(slug);
+        var serverSideEvaluation = FindEvaluationBySlug(slug);
 
         if (serverSideEvaluation == null)
         {

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContext.cs
@@ -3,32 +3,34 @@ using System.Collections.Concurrent;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Murmur;
+using Octopus.OpenFeature.Provider.V4;
 using OpenFeature.Constant;
+using OpenFeature.Error;
 using OpenFeature.Model;
 
 namespace Octopus.OpenFeature.Provider;
 
-partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory loggerFactory)
+internal class OctopusFeatureContext(EvaluationResponse evaluationResponse, ILoggerFactory loggerFactory)
 {
-    public byte[] ContentHash => toggles.ContentHash;
+    public byte[] ContentHash => evaluationResponse.ContentHash;
     readonly ILogger logger = loggerFactory.CreateLogger<OctopusFeatureContext>();
     readonly ConcurrentDictionary<string, byte> warnedSlugs = new(StringComparer.OrdinalIgnoreCase);
 
     public static OctopusFeatureContext Empty(ILoggerFactory loggerFactory)
     {
-        return new OctopusFeatureContext(new FeatureToggles([], []), loggerFactory);
+        return new OctopusFeatureContext(new EvaluationResponse([], []), loggerFactory);
     }
 
-    internal FeatureToggleEvaluation? FindFeatureToggleBySlug(string slug)
+    internal ServerSideEvaluation? FindFeatureToggleBySlug(string slug)
     {
-        return toggles.Evaluations.FirstOrDefault(x => x.Slug.Equals(slug, StringComparison.OrdinalIgnoreCase));
+        return evaluationResponse.Evaluations.FirstOrDefault(x => x.Slug.Equals(slug, StringComparison.OrdinalIgnoreCase));
     }
 
-    public ResolutionDetails<bool> Evaluate(string slug, bool defaultValue, EvaluationContext? context)
+    public ResolutionDetails<bool> Evaluate(string slug, EvaluationContext? context)
     {
-        var feature = FindFeatureToggleBySlug(slug);
+        var serverSideEvaluation = FindFeatureToggleBySlug(slug);
 
-        if (feature == null)
+        if (serverSideEvaluation == null)
         {
             if (warnedSlugs.TryAdd(slug, 0))
             {
@@ -37,17 +39,10 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
                     slug);
             }
 
-            return new ResolutionDetails<bool>(slug, defaultValue, ErrorType.FlagNotFound,
-                "The slug provided did not match any of your Octopus Feature Toggles. Please double check your slug and try again.");
+            throw new FlagNotFoundException("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.");
         }
-
-        if (MissingRequiredPropertiesForClientSideEvaluation(feature))
-        {
-            return new ResolutionDetails<bool>(slug, defaultValue, ErrorType.ParseError,
-                $"Feature toggle {slug} is missing necessary information for client-side evaluation.");
-        }
-
-        return new ResolutionDetails<bool>(slug, Evaluate(feature, context));
+        
+        return serverSideEvaluation.Evaluate(context);
     }
 
     bool MatchesSegment(EvaluationContext? context, IEnumerable<KeyValuePair<string, string>> segments)
@@ -69,6 +64,8 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
 
     bool Evaluate(FeatureToggleEvaluation evaluation, EvaluationContext? context = null)
     {
+        // Remove in BMBB-702
+        
         if (!evaluation.IsEnabled)
         {
             return false;
@@ -102,6 +99,8 @@ partial class OctopusFeatureContext(FeatureToggles toggles, ILoggerFactory logge
     /// </summary>
     internal static int GetNormalizedNumber(string evaluationKey, string targetingKey)
     {
+        // Move to own class in BMBB-702. Perhaps copy+paste of PercentageRollout.cs in OctoToggle?
+        
         var bytes = Encoding.UTF8.GetBytes(string.Concat(evaluationKey, ":", targetingKey));
 
         using var algorithm = MurmurHash.Create32();

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
@@ -30,10 +30,10 @@ class OctopusFeatureContextProvider(
 
         try
         {
-            var toggles = await client.GetFeatureToggleEvaluationManifest(cancellationTokenSource.Token);
+            var evaluationResponse = await client.GetServerSideEvaluations(cancellationTokenSource.Token);
             currentContext =
-                toggles is not null
-                    ? new OctopusFeatureContext(toggles, configuration.LoggerFactory)
+                evaluationResponse is not null
+                    ? new OctopusFeatureContext(evaluationResponse, configuration.LoggerFactory)
                     : OctopusFeatureContext.Empty(configuration.LoggerFactory);
         }
         catch (Exception e)
@@ -61,7 +61,7 @@ class OctopusFeatureContextProvider(
 
                 if (await client.HaveFeaturesChanged(currentContext.ContentHash, cancellationToken))
                 {
-                    var toggles = await client.GetFeatureToggleEvaluationManifest(cancellationToken);
+                    var toggles = await client.GetServerSideEvaluations(cancellationToken);
                     if (toggles is not null)
                     {
                         currentContext = new OctopusFeatureContext(toggles, configuration.LoggerFactory);

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureContextProvider.cs
@@ -5,7 +5,7 @@ namespace Octopus.OpenFeature.Provider;
 /// <summary>
 /// Establishes and maintains a cache of evaluated feature toggles to be used by the feature provider.
 /// </summary>
-class OctopusFeatureContextProvider(
+internal class OctopusFeatureContextProvider(
     OctopusFeatureConfiguration configuration,
     IOctopusFeatureClient client,
     ILogger logger)

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
@@ -79,10 +79,10 @@ public class OctopusFeatureProvider : FeatureProvider
     Exception RejectNonBooleanEvaluation(string flagKey)
     {
         var evaluator = contextProvider.GetEvaluationContext();
-        var toggle = evaluator.FindFeatureToggleBySlug(flagKey);
+        var toggle = evaluator.FindEvaluationBySlug(flagKey);
         if (toggle == null)
         {
-            return new FlagNotFoundException(flagKey);
+            return new FlagNotFoundException("The slug provided did not match any of your Octopus Feature Flags. Please double check your slug and try again.");
         }
         return new TypeMismatchException("Octopus only supports boolean flags.");
     }

--- a/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusFeatureProvider.cs
@@ -47,7 +47,7 @@ public class OctopusFeatureProvider : FeatureProvider
 
         var evaluator = contextProvider.GetEvaluationContext();
 
-        var isFeatureEnabled = evaluator.Evaluate(flagKey, defaultValue, context);
+        var isFeatureEnabled = evaluator.Evaluate(flagKey, context);
 
         return isFeatureEnabled;
     }

--- a/src/Octopus.OpenFeature.Provider/OctopusHttpHeaderNames.cs
+++ b/src/Octopus.OpenFeature.Provider/OctopusHttpHeaderNames.cs
@@ -1,6 +1,6 @@
 ﻿namespace Octopus.OpenFeature.Provider;
 
-public static class OctopusHttpHeaderNames
+internal static class OctopusHttpHeaderNames
 {
     public const string ReleaseVersion = "X-Release-Version";
 }

--- a/src/Octopus.OpenFeature.Provider/V4/Conditions/ContextAttributeIsNotOneOfCondition.cs
+++ b/src/Octopus.OpenFeature.Provider/V4/Conditions/ContextAttributeIsNotOneOfCondition.cs
@@ -1,8 +1,7 @@
 namespace Octopus.OpenFeature.Provider.V4.Conditions;
 
 /// <summary>
-/// Matches when the context attribute <see cref="Key"/> is not one of <see cref="Values"/>. A missing
-/// attribute matches, mirroring OctoToggle's <c>TenantIsNotOneOf</c>, where an untenanted caller always
+/// Matches when the context attribute <see cref="Key"/> is not one of <see cref="Values"/>. A missing attribute
 /// matches.
 /// </summary>
 internal sealed class ContextAttributeIsNotOneOfCondition : ClientSideCondition

--- a/src/Octopus.OpenFeature.Provider/V4/EvaluationReasons.cs
+++ b/src/Octopus.OpenFeature.Provider/V4/EvaluationReasons.cs
@@ -1,7 +1,7 @@
 namespace Octopus.OpenFeature.Provider.V4;
 
 /// <summary>
-/// Reasons returned alongside a client-side evaluation. Both match the strings OctoToggle produces
+/// Reasons returned alongside a client-side evaluation. Both match the strings the Feature Flags service produces
 /// server-side, so a flag reads the same whichever side resolved it.
 /// </summary>
 internal static class EvaluationReasons

--- a/src/Octopus.OpenFeature.Provider/V4/ServerSideEvaluation.cs
+++ b/src/Octopus.OpenFeature.Provider/V4/ServerSideEvaluation.cs
@@ -55,7 +55,7 @@ internal sealed class ServerSideEvaluation
             {
                 throw new ParseErrorException("The flag has a value but has no reason.");
             }
-            
+
             if (EvaluationKey is not null || Rules is not null)
             {
                 throw new ParseErrorException("The flag has both a server-resolved value and client-side rules.");

--- a/src/Octopus.OpenFeature.Provider/V4/ServerSideEvaluation.cs
+++ b/src/Octopus.OpenFeature.Provider/V4/ServerSideEvaluation.cs
@@ -51,6 +51,11 @@ internal sealed class ServerSideEvaluation
     {
         if (Value is { } value)
         {
+            if (Reason is null)
+            {
+                throw new ParseErrorException("The flag has a value but has no reason.");
+            }
+            
             if (EvaluationKey is not null || Rules is not null)
             {
                 throw new ParseErrorException("The flag has both a server-resolved value and client-side rules.");


### PR DESCRIPTION
# Background

Octopus Feature Flags are moving from a single form-based configuration to rules-based evaluation.

New API endpoints have been added to the Feature Flags service with a `v4` designation.

Existing form-based Feature Flags evaluations are live translated so that the provider libraries, including this one, can switch to the `v4` endpoints now and seamlessly migrate to the rules-based evaluation when it becomes available in Octopus.

**Note:** Due to the significance of this change it has been marked as a breaking change, though we expect consumers will be able to update without any code or functionality changes.

# Changes

* Updated to use new `v4` endpoints, including deserialising into new rules-based evaluation types.
* Updated flag evaluation to use [new rules-based evaluation](https://github.com/OctopusDeploy/openfeature-provider-dotnet/pull/93).
* Updated some classes to be `internal` to allow future changes without being a breaking change.

Resolves BMBB-676.

# Notes for review

* Some dead `v3` code has been deliberately left behind to keep PR size small. To be cleaned up in https://linear.app/octopus/issue/BMBB-702/clean-up-v3-code.

# Testing

* Updated to latest [specification tests](https://github.com/OctopusDeploy/openfeature-provider-specification).
* We'll do full end-to-end testing of the library before publishing.


BEGIN_COMMIT_OVERRIDE
feat: Add support for upcoming rules-based evaluations
END_COMMIT_OVERRIDE